### PR TITLE
Play jump replay at player's current position if map is wrong

### DIFF
--- a/addons/sourcemod/scripting/gokz-replays/api.sp
+++ b/addons/sourcemod/scripting/gokz-replays/api.sp
@@ -24,7 +24,7 @@ public int Native_RP_LoadJumpReplay(Handle plugin, int numParams)
 	GetNativeStringLength(2, len);
 	char[] path = new char[len + 1];
 	GetNativeString(2, path, len + 1);
-	int botClient = LoadReplayBot(GetNativeCell(1), path);
+	int botClient = LoadReplayBot(GetNativeCell(1), path, true);
 	return botClient;
 }
 

--- a/addons/sourcemod/scripting/gokz-replays/playback.sp
+++ b/addons/sourcemod/scripting/gokz-replays/playback.sp
@@ -43,6 +43,8 @@ static bool hitBhop[RP_MAX_BOTS];
 static bool hitPerf[RP_MAX_BOTS];
 static bool botJumped[RP_MAX_BOTS];
 static bool botIsTakeoff[RP_MAX_BOTS];
+static bool isJumpReplay[RP_MAX_BOTS];
+static float jumpReplayOffset[RP_MAX_BOTS][3];
 static float botLandingSpeed[RP_MAX_BOTS];
 
 
@@ -50,7 +52,7 @@ static float botLandingSpeed[RP_MAX_BOTS];
 // =====[ PUBLIC ]=====
 
 // Returns the client index of the replay bot, or -1 otherwise
-int LoadReplayBot(int client, char[] path)
+int LoadReplayBot(int client, char[] path, bool jumpReplay = false)
 {
 	int bot;
 	if (GetBotsInUse() < RP_MAX_BOTS)
@@ -73,7 +75,10 @@ int LoadReplayBot(int client, char[] path)
 		GOKZ_PlayErrorSound(client);
 		return -1;
 	}
-
+	
+	isJumpReplay[bot] = jumpReplay;
+	jumpReplayOffset[bot] = NULL_VECTOR;
+	
 	if (!LoadPlayback(client, bot, path))
 	{
 		GOKZ_PlayErrorSound(client);
@@ -448,10 +453,19 @@ static bool LoadFormatVersion2Replay(File file, int client, int bot)
 	char[] mapName = new char[length + 1];
 	file.ReadString(mapName, length, length);
 	mapName[length] = '\0';
+	bool wrongMap = false;
 	if (!StrEqual(mapName, gC_CurrentMap))
 	{
-		GOKZ_PrintToChat(client, true, "%t", "Replay Menu - Wrong Map", mapName);
-		return false;
+		if (!isJumpReplay[bot])
+		{
+			GOKZ_PrintToChat(client, true, "%t", "Replay Menu - Wrong Map", mapName);
+			return false;
+		}
+		else
+		{
+			GOKZ_PrintToChat(client, true, "%t", "Replay Menu - Jump Replay Wrong Map", mapName);
+			wrongMap = true;
+		}
 	}
 
 	// Map filesize
@@ -619,6 +633,14 @@ static bool LoadFormatVersion2Replay(File file, int client, int bot)
 		
 		ReplayTickData tickData;
 		TickDataFromArray(tickDataArray, tickData);
+		
+		if (i == 0 && wrongMap && isJumpReplay[bot])
+		{
+			float playerOrigin[3];
+			GetClientAbsOrigin(client, playerOrigin);
+			SubtractVectors(playerOrigin, tickData.origin, jumpReplayOffset[bot]);
+		}
+		
 		// HACK: Jump replays don't record proper length sometimes. I don't know why.
 		//		 This leads to oversized replays full of 0s at the end.
 		// 		 So, we do this horrible check to dodge that issue.
@@ -824,6 +846,13 @@ void PlaybackVersion2(int client, int bot, int &buttons)
 		// Move the bot and pause them at that tick
 		playbackTickData[bot].GetArray(playbackTick[bot], currentTickData);
 		playbackTickData[bot].GetArray(IntMax(playbackTick[bot] - 1, 0), prevTickData);
+		
+		if (isJumpReplay[bot] && !IsNullVector(jumpReplayOffset[bot]))
+		{
+			AddVectors(currentTickData.origin, jumpReplayOffset[bot], currentTickData.origin);
+			AddVectors(prevTickData.origin, jumpReplayOffset[bot], prevTickData.origin);
+		}
+		
 		TeleportEntity(client, currentTickData.origin, currentTickData.angles, view_as<float>( { 0.0, 0.0, 0.0 } ));
 		
 		if (!inBreather[bot])
@@ -872,6 +901,12 @@ void PlaybackVersion2(int client, int bot, int &buttons)
 		// Load in the next tick
 		playbackTickData[bot].GetArray(playbackTick[bot], currentTickData);
 		playbackTickData[bot].GetArray(IntMax(playbackTick[bot] - 1, 0), prevTickData);
+		
+		if (isJumpReplay[bot] && !IsNullVector(jumpReplayOffset[bot]))
+		{
+			AddVectors(currentTickData.origin, jumpReplayOffset[bot], currentTickData.origin);
+			AddVectors(prevTickData.origin, jumpReplayOffset[bot], prevTickData.origin);
+		}
 		
 		// Check if the replay is paused
 		if (botPlaybackPaused[bot])

--- a/addons/sourcemod/translations/gokz-replays.phrases.txt
+++ b/addons/sourcemod/translations/gokz-replays.phrases.txt
@@ -53,6 +53,11 @@
 		"#format"	"{1:s}"
 		"en"		"{darkred}This replay was not recorded on this map. Please switch to {1} and try again."
 	}
+	"Replay Menu - Jump Replay Wrong Map"
+	{
+		"#format"	"{1:s}"
+		"en"		"{darkred}Warning! This jump replay was not recorded on this map, it will play from your current location. Please switch to {1} if you want to see better playback."
+	}
 	"Replay Menu - No File"
 	{
 		"en"		"{darkred}There is no file for this replay. Please contact an admin if you think this is an error."


### PR DESCRIPTION
If the current map doesn’t match the jump replay’s map, then it’ll play from the player’s current position. This is better than not playing at all cos the map isn’t going to be correct 99% of the time.