### PR TITLE
Ensure that ladderjump jumpstat isn't a ladderhop from midair

### DIFF
--- a/addons/sourcemod/scripting/gokz-jumpstats/jump_tracking.sp
+++ b/addons/sourcemod/scripting/gokz-jumpstats/jump_tracking.sp
@@ -1289,7 +1289,7 @@ void OnJumpValidated_JumpTracking(int client, bool jumped, bool ladderJump, bool
 	// If it is then this is not a valid jumpstat.	
 	int buttons = GetClientButtons(client);
 	float ignoreLadderJumpTime = GetEntPropFloat(client, Prop_Data, "m_ignoreLadderJumpTime");
-	if (buttons & IN_JUMP && ignoreLadderJumpTime <= GetGameTime())
+	if (ladderJump && buttons & IN_JUMP && ignoreLadderJumpTime <= GetGameTime())
 	{
 		return;
 	}

--- a/addons/sourcemod/scripting/gokz-jumpstats/jump_tracking.sp
+++ b/addons/sourcemod/scripting/gokz-jumpstats/jump_tracking.sp
@@ -1285,6 +1285,15 @@ void OnJumpValidated_JumpTracking(int client, bool jumped, bool ladderJump, bool
 		return;
 	}
 
+	// Check if this change of move type is caused by ladder hopping in the air.
+	// If it is then this is not a valid jumpstat.	
+	int buttons = GetClientButtons(client);
+	float ignoreLadderJumpTime = GetEntPropFloat(client, Prop_Data, "m_ignoreLadderJumpTime");
+	if (buttons & IN_JUMP && ignoreLadderJumpTime <= GetGameTime())
+	{
+		return;
+	}
+
 	// Update: Takeoff speed should be always correct with the new MovementAPI.
 	if (jumped)
 	{


### PR DESCRIPTION
Related to this PR here on MovementAPI: https://github.com/danzayau/MovementAPI/pull/27

I just add a check to prevent that from happening.