### PR TITLE
Set tickCount at initialization

### DIFF
--- a/addons/sourcemod/scripting/gokz-jumpstats/jump_tracking.sp
+++ b/addons/sourcemod/scripting/gokz-jumpstats/jump_tracking.sp
@@ -80,6 +80,7 @@ enum struct JumpTracker
 		this.jumper = jumper;
 		this.jump.jumper = jumper;
 		this.nextCrouchRelease = 100;
+		this.tickCount = GetGameTickCount();
 	}
 	
 	


### PR DESCRIPTION
Fixes a bug where jumpstats would not be registered until a certain tick was reached. This only happens when the map is changed and for every time this happens the amount of ticks until jumpstats work again is incremented.

How to replicate:

Once loaded in, change map. Jumpstats will not work for a little while. Repeat and the next time you're loaded in the amount of ticks until jumpstats work is incremented.