### PR TITLE
Fix increased airaccel due to prestrafing

### DIFF
--- a/addons/sourcemod/scripting/gokz-mode-kztimer.sp
+++ b/addons/sourcemod/scripting/gokz-mode-kztimer.sp
@@ -69,12 +69,14 @@ float gF_PreVelModLastChange[MAXPLAYERS + 1];
 float gF_RealPreVelMod[MAXPLAYERS + 1];
 int gI_PreTickCounter[MAXPLAYERS + 1];
 Handle gH_GetPlayerMaxSpeed;
+DynamicDetour gH_AirAccelerate;
 int gI_OldButtons[MAXPLAYERS + 1];
 int gI_OldFlags[MAXPLAYERS + 1];
 bool gB_OldOnGround[MAXPLAYERS + 1];
 float gF_OldAngles[MAXPLAYERS + 1][3];
 float gF_OldVelocity[MAXPLAYERS + 1][3];
 bool gB_Jumpbugged[MAXPLAYERS + 1];
+int gI_OffsetCGameMovement_player;
 
 
 
@@ -188,6 +190,25 @@ public MRESReturn DHooks_OnGetPlayerMaxSpeed(int client, Handle hReturn)
 	return MRES_Supercede;
 }
 
+public MRESReturn DHooks_OnAirAccelerate_Pre(Address pThis, DHookParam hParams)
+{
+	int client = GOKZGetClientFromGameMovementAddress(pThis, gI_OffsetCGameMovement_player);
+	if (!IsPlayerAlive(client) || !IsUsingMode(client))
+	{
+		return MRES_Ignored;
+	}
+	
+	// NOTE: Prestrafing changes GetPlayerMaxSpeed, which changes air acceleration, so if wishspeed is bigger than SPEED_NORMAL, cap it.
+	float wishspeed = DHookGetParam(hParams, 2);
+	if (wishspeed > SPEED_NORMAL)
+	{
+		DHookSetParam(hParams, 2, SPEED_NORMAL);
+		return MRES_ChangedHandled;
+	}
+	
+	return MRES_Ignored;
+}
+
 public void SDKHook_OnClientPreThink_Post(int client)
 {
 	if (!IsPlayerAlive(client) || !IsUsingMode(client))
@@ -295,12 +316,35 @@ bool IsUsingMode(int client)
 void HookEvents()
 {
 	GameData gameData = LoadGameConfigFile("movementapi.games");
+	if (gameData == INVALID_HANDLE)
+	{
+		SetFailState("Failed to find movementapi.games config");
+	}
+	
 	int offset = gameData.GetOffset("GetPlayerMaxSpeed");
 	if (offset == -1)
 	{
 		SetFailState("Failed to get GetPlayerMaxSpeed offset");
 	}
 	gH_GetPlayerMaxSpeed = DHookCreate(offset, HookType_Entity, ReturnType_Float, ThisPointer_CBaseEntity, DHooks_OnGetPlayerMaxSpeed);
+	
+	gH_AirAccelerate = DynamicDetour.FromConf(gameData, "CGameMovement::AirAccelerate");
+	if (gH_AirAccelerate == INVALID_HANDLE)
+	{
+		SetFailState("Failed to find CGameMovement::AirAccelerate function signature");
+	}
+	
+	if (!gH_AirAccelerate.Enable(Hook_Pre, DHooks_OnAirAccelerate_Pre))
+	{
+		SetFailState("Failed to enable detour on CGameMovement::AirAccelerate");
+	}
+	
+	char buffer[16];
+	if (!gameData.GetKeyValue("CGameMovement::player", buffer, sizeof(buffer)))
+	{
+		SetFailState("Failed to get CGameMovement::player offset.");
+	}
+	gI_OffsetCGameMovement_player = StringToInt(buffer);
 }
 
 // =====[ CONVARS ]=====

--- a/addons/sourcemod/scripting/gokz-mode-kztimer.sp
+++ b/addons/sourcemod/scripting/gokz-mode-kztimer.sp
@@ -198,11 +198,14 @@ public MRESReturn DHooks_OnAirAccelerate_Pre(Address pThis, DHookParam hParams)
 		return MRES_Ignored;
 	}
 	
-	// NOTE: Prestrafing changes GetPlayerMaxSpeed, which changes air acceleration, so if wishspeed is bigger than SPEED_NORMAL, cap it.
+	// NOTE: Prestrafing changes GetPlayerMaxSpeed, which changes
+	// air acceleration, so remove gF_PreVelMod[client] from wishspeed/maxspeed.
+	// This also applies to when the player is ducked: their wishspeed is
+	// 85 and with prestrafing can be ~93.
 	float wishspeed = DHookGetParam(hParams, 2);
-	if (wishspeed > SPEED_NORMAL)
+	if (gF_PreVelMod[client] > 1.0)
 	{
-		DHookSetParam(hParams, 2, SPEED_NORMAL);
+		DHookSetParam(hParams, 2, wishspeed / gF_PreVelMod[client]);
 		return MRES_ChangedHandled;
 	}
 	

--- a/addons/sourcemod/scripting/gokz-mode-simplekz.sp
+++ b/addons/sourcemod/scripting/gokz-mode-simplekz.sp
@@ -210,11 +210,14 @@ public MRESReturn DHooks_OnAirAccelerate_Pre(Address pThis, DHookParam hParams)
 		return MRES_Ignored;
 	}
 	
-	// NOTE: Prestrafing changes GetPlayerMaxSpeed, which changes air acceleration, so if wishspeed is bigger than SPEED_NORMAL, cap it.
+	// NOTE: Prestrafing changes GetPlayerMaxSpeed, which changes
+	// air acceleration, so remove gF_PreVelMod[client] from wishspeed/maxspeed.
+	// This also applies to when the player is ducked: their wishspeed is
+	// 85 and with prestrafing can be ~93.
 	float wishspeed = DHookGetParam(hParams, 2);
-	if (wishspeed > SPEED_NORMAL)
+	if (gF_PSVelMod[client] > 1.0)
 	{
-		DHookSetParam(hParams, 2, SPEED_NORMAL);
+		DHookSetParam(hParams, 2, wishspeed / gF_PSVelMod[client]);
 		return MRES_ChangedHandled;
 	}
 	

--- a/addons/sourcemod/scripting/include/gokz.inc
+++ b/addons/sourcemod/scripting/include/gokz.inc
@@ -930,3 +930,55 @@ static bool CanSeeBox(float origin[3], float center[3], float distFromCenter[3])
 	delete trace;
 	return true;
 }
+
+/**
+ * Gets entity index from the address to an entity.
+ *
+ * @param pEntity			Entity address.
+ * @return					Entity index.
+ * @error					Couldn't find offset for m_angRotation, m_vecViewOffset, couldn't confirm offset of m_RefEHandle.
+ */
+stock int GOKZGetEntityFromAddress(Address pEntity)
+{
+	static int offs_RefEHandle;
+	if (offs_RefEHandle)
+	{
+		return EntRefToEntIndex(LoadFromAddress(pEntity + view_as<Address>(offs_RefEHandle), NumberType_Int32) | (1 << 31));
+	}
+	
+	// if we don't have it already, attempt to lookup offset based on SDK information
+	// CWorld is derived from CBaseEntity so it should have both offsets
+	int offs_angRotation = FindDataMapInfo(0, "m_angRotation"), offs_vecViewOffset = FindDataMapInfo(0, "m_vecViewOffset");
+	if (offs_angRotation == -1)
+	{
+		SetFailState("Could not find offset for ((CBaseEntity) CWorld)::m_angRotation");
+	}
+	else if (offs_vecViewOffset == -1)
+	{
+		SetFailState("Could not find offset for ((CBaseEntity) CWorld)::m_vecViewOffset");
+	}
+	else if ((offs_angRotation + 0x0C) != (offs_vecViewOffset - 0x04))
+	{
+		char game[32];
+		GetGameFolderName(game, sizeof(game));
+		SetFailState("Could not confirm offset of CBaseEntity::m_RefEHandle (incorrect assumption for game '%s'?)", game);
+	}
+	
+	// offset seems right, cache it for the next call
+	offs_RefEHandle = offs_angRotation + 0x0C;
+	return GOKZGetEntityFromAddress(pEntity);
+}
+
+/**
+ * Gets client index from CGameMovement class.
+ *
+ * @param addr							Address of CGameMovement class.
+ * @param offsetCGameMovement_player	Offset of CGameMovement::player.
+ * @return								Client index.
+ * @error								Couldn't find offset for m_angRotation, m_vecViewOffset, couldn't confirm offset of m_RefEHandle.
+ */
+stock int GOKZGetClientFromGameMovementAddress(Address addr, int offsetCGameMovement_player)
+{
+	Address playerAddr = view_as<Address>(LoadFromAddress(view_as<Address>(view_as<int>(addr) + offsetCGameMovement_player), NumberType_Int32));
+	return GOKZGetEntityFromAddress(playerAddr);
+}


### PR DESCRIPTION
Prestrafing now hooks GetPlayerMaxSpeed, which changes airacceleration, so I hooked AirAccelerate to cap it.
This could be done a bit easier by using m_flVelocityModifier since that doesn't modify maxspeed while in the air, **but** that causes another issue where if you jumpbug without perfing and have prestrafe your jump will have 250 pre or less because the game thinks that you're in the air. This fixes both issues.