### PR TITLE
Overrides for tag access

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -63,6 +63,11 @@ Sets player models upon spawning to models that have more subtle landing animati
 
 Displays information about players, including ranks derived from the Global API.
 
+The plugin also provides "ADMIN" and "VIP" flags. Access to using these flags can be overridden by giving access to the following Sourcemod "commands":
+
+* `gokz_flag_admin` (Default `ADMFLAG_GENERIC`).
+* `gokz_flag_vip` (Default `ADMFLAG_CUSTOM1`).
+
 ### gokz-quiet
 
 Adds options and features to reduce visual and audio noise, such as hiding other players.

--- a/addons/sourcemod/scripting/gokz-profile/options.sp
+++ b/addons/sourcemod/scripting/gokz-profile/options.sp
@@ -121,14 +121,14 @@ public void TopMenuHandler_Profile(TopMenu topmenu, TopMenuAction action, TopMen
 					}
 					case ProfileTagType_Admin:
 					{
-						if (GetAdminFlag(GetUserAdmin(param), Admin_Ban))
+						if (CheckCommandAccess(param, "gokz_flag_admin", ADMFLAG_GENERIC))
 						{
 							break;
 						}
 					}
 					case ProfileTagType_VIP:
 					{
-						if (GetAdminFlag(GetUserAdmin(param), Admin_Custom1))
+						if (CheckCommandAccess(param, "gokz_flag_vip", ADMFLAG_CUSTOM1))
 						{
 							break;
 						}


### PR DESCRIPTION
This change will change the access check for the VIP and ADMIN tag to use command access instead of checking flags directly by using non-existent "commands". This will allow server administrators to override the admin flags required for accessing the tags by using Sourcemod's override system, thus not forcing specific flags to be used.