### PR TITLE
Invalidate jumps with externally modified velocity for one more tick

### DIFF
--- a/addons/sourcemod/scripting/gokz-jumpstats.sp
+++ b/addons/sourcemod/scripting/gokz-jumpstats.sp
@@ -30,6 +30,9 @@ public Plugin myinfo =
 
 #define UPDATER_URL GOKZ_UPDATER_BASE_URL..."gokz-jumpstats.txt"
 
+// This must be global because it's both used by jump tracking and validating.
+bool gB_SpeedJustModifiedExternally[MAXPLAYERS + 1];
+
 #include "gokz-jumpstats/api.sp"
 #include "gokz-jumpstats/commands.sp"
 #include "gokz-jumpstats/distance_tiers.sp"
@@ -38,7 +41,6 @@ public Plugin myinfo =
 #include "gokz-jumpstats/jump_validating.sp"
 #include "gokz-jumpstats/options.sp"
 #include "gokz-jumpstats/options_menu.sp"
-
 
 
 // =====[ PLUGIN EVENTS ]=====

--- a/addons/sourcemod/scripting/gokz-jumpstats/jump_tracking.sp
+++ b/addons/sourcemod/scripting/gokz-jumpstats/jump_tracking.sp
@@ -274,7 +274,7 @@ enum struct JumpTracker
 	
 	int DetermineType(bool jumped, bool ladderJump, bool jumpbug)
 	{
-		if (this.tickCount - this.lastTeleportTick < JS_MIN_TELEPORT_DELAY)
+		if (gB_SpeedJustModifiedExternally[this.jumper] || this.tickCount - this.lastTeleportTick < JS_MIN_TELEPORT_DELAY)
 		{
 			return JumpType_Invalid;
 		}

--- a/addons/sourcemod/scripting/gokz-jumpstats/jump_validating.sp
+++ b/addons/sourcemod/scripting/gokz-jumpstats/jump_validating.sp
@@ -65,6 +65,7 @@ static MRESReturn DHook_ProcessMovementPost(Handle hParams)
 	Movement_GetProcessingVelocity(client, pVelocity);
 	Movement_GetVelocity(client, velocity);
 
+	gB_SpeedJustModifiedExternally[client] = false;
 	for (int i = 0; i < 3; i++)
 	{
 		if (FloatAbs(pVelocity[i] - velocity[i]) > EPSILON)
@@ -72,6 +73,7 @@ static MRESReturn DHook_ProcessMovementPost(Handle hParams)
 			// The current velocity doesn't match the velocity of the end of movement processing,
 			// so it must have been modified by something like a trigger.
 			InvalidateJumpstat(client);
+			gB_SpeedJustModifiedExternally[client] = true;
 			break;
 		}
 	}


### PR DESCRIPTION
It is possible that InvalidateJumpstat is called, and then the jump gets validated in the same tick in DetermineType, causing a false jumpstat.