### PR TITLE
Allow player to press buttons through players

### DIFF
--- a/addons/sourcemod/scripting/gokz-core.sp
+++ b/addons/sourcemod/scripting/gokz-core.sp
@@ -281,6 +281,11 @@ public void OnCSPlayerSpawnPost(int client)
 	}
 }
 
+public void OnClientPreThinkPost(int client)
+{
+	OnClientPreThinkPost_UseButtons(client);
+}
+
 public void Movement_OnChangeMovetype(int client, MoveType oldMovetype, MoveType newMovetype)
 {
 	OnChangeMovetype_Timer(client, newMovetype);
@@ -513,6 +518,7 @@ static void HookClientEvents(int client)
 	DHookEntity(gH_DHooks_OnTeleport, true, client);
 	DHookEntity(gH_DHooks_SetModel, true, client);
 	SDKHook(client, SDKHook_SpawnPost, OnCSPlayerSpawnPost);
+	SDKHook(client, SDKHook_PreThinkPost, OnClientPreThinkPost);
 }
 
 static void UpdateTrackingVariables(int client, int cmdnum, int buttons)

--- a/addons/sourcemod/scripting/gokz-core/misc.sp
+++ b/addons/sourcemod/scripting/gokz-core/misc.sp
@@ -572,3 +572,179 @@ void OnMapStart_FixMissingSpawns()
 		}
 	}
 }
+
+static void AutoJoinTeam(int client)
+{
+	int team = GetRandomInt(CS_TEAM_T, CS_TEAM_CT);
+	JoinTeam(client, team, false);
+}
+
+// =====[ BUTTONS ]=====
+
+void OnClientPreThinkPost_UseButtons(int client)
+{
+	if (GetEntProp(client, Prop_Data, "m_afButtonPressed") & IN_USE)
+	{
+		int entity = FindUseEntity(client);
+		if (entity != -1)
+		{
+			AcceptEntityInput(entity, "Use", client, client, 1);
+		}
+	}
+}
+
+static int FindUseEntity(int client)
+{
+	float fwd[3];
+	float angles[3];
+	GetClientEyeAngles(client, angles);
+	GetAngleVectors(angles, fwd, NULL_VECTOR, NULL_VECTOR);
+
+	Handle trace;
+
+	float eyeOrigin[3];
+	GetClientEyePosition(client, eyeOrigin);
+	int useableContents = (MASK_NPCSOLID_BRUSHONLY | MASK_OPAQUE_AND_NPCS) & ~CONTENTS_OPAQUE;
+
+	float endpos[3];
+
+	// Check if +use trace collide with a player first, so we don't activate any button twice
+	trace = TR_TraceRayFilterEx(eyeOrigin, angles, useableContents, RayType_Infinite, TRFOtherPlayersOnly, client);
+	if (TR_DidHit(trace))
+	{
+		int ent = TR_GetEntityIndex(trace);
+		if (ent < 1 || ent > MaxClients)
+		{
+			return -1;
+		}
+		// Search for a button behind it.
+		trace = TR_TraceRayFilterEx(eyeOrigin, angles, useableContents, RayType_Infinite, TraceEntityFilterPlayers);
+		if (TR_DidHit(trace))
+		{
+			char buffer[20];
+			ent = TR_GetEntityIndex(trace);
+			// Make sure that it is a button, and this button activates when pressed.
+			// If it is not a button, check its parent to see if it is a button.
+			bool isButton;
+			while (ent != -1)
+			{
+				GetEntityClassname(ent, buffer, sizeof(buffer));
+				if (StrEqual("func_button", buffer, false) && GetEntProp(ent, Prop_Data, "m_spawnflags") & SF_BUTTON_USE_ACTIVATES)
+				{
+					isButton = true;
+					break;
+				}
+				else
+				{
+					ent = GetEntPropEnt(ent, Prop_Data, "m_hMoveParent");
+				}
+			}
+			if (isButton)
+			{
+				TR_GetEndPosition(endpos, trace);
+				float delta[3];
+				for (int i = 0; i < 2; i++)
+				{
+					delta[i] = endpos[i] - eyeOrigin[i];
+				}
+				// Z distance is treated differently.
+				float m_vecMins[3];
+				float m_vecMaxs[3];
+				float m_vecOrigin[3];
+				GetEntPropVector(ent, Prop_Send, "m_vecOrigin", m_vecOrigin);
+				GetEntPropVector(ent, Prop_Send, "m_vecMins", m_vecMins);
+				GetEntPropVector(ent, Prop_Send, "m_vecMaxs", m_vecMaxs);
+
+				delta[2] = IntervalDistance(endpos[2], m_vecOrigin[2] + m_vecMins[2], m_vecOrigin[2] + m_vecMaxs[2]);
+				if (GetVectorLength(delta) < 80.0)
+				{
+					return ent;
+				}
+			}
+		}
+	}
+	// This is 1.11 only.
+	/*
+	float nearestPoint[3];
+	float nearestDist = FLOAT_MAX;
+	ArrayList entities;
+	TR_EnumerateEntitiesSphere(eyeOrigin, 80.0, 0, AddEntities, entities);
+	for (int i = 0; i < entities.Length; i++)
+	{
+		char buffer[64];
+		int ent = entities.Get(i);
+		GetEntityClassname(ent, buffer, sizeof(buffer));
+		if (StrEqual("func_button", buffer, false) && GetEntProp(entity, Prop_Data, "m_spawnflags") & SF_BUTTON_USE_ACTIVATES)
+		{
+			float point[3];
+			CalcNearestPoint(ent, eyeOrigin, point);
+						
+			float dir[3];
+			for (int j = 0; j < 3; j++)
+			{
+				dir[j] = point[j] - eyeOrigin[2];
+			}
+
+			float minimumDot = GetEntPropFloat(ent, Prop_Send, "m_flUseLookAtAngle");
+			float dot = GetVectorDotProduct(dir, fwd);
+			if (dot < minimumDot)
+			{
+				continue;
+			}
+
+			float dist = CalcDistanceToLine(point, eyeOrigin, fwd);
+			if (dist < nearestDist)
+			{
+				trace = TR_TraceRayFilterEx(eyeOrigin, point, useableContents, RayType_EndPoint, TraceEntityFilterPlayers);
+				if (TR_GetFraction(trace) == 1.0 || TR_GetEntityIndex(trace) == ent)
+				{
+					CopyVector(point, nearestPoint);
+					entity = ent;
+					nearestDist = dist;
+				}
+			}
+		}
+	}
+	// We found the closest button, but we still need to check if there is a player in front of it or not.
+	// In the case that there isn't a player inbetween, we don't return the entity index, because that button will be pressed by the game function anyway.
+	// If there is, we will press two buttons at once, the "right" button found by this function and the "wrong" button that we only happen to press because
+	// there is a player in the way.
+	
+	trace = TR_TraceRayFilterEx(eyeOrigin, nearestPoint, useableContents, RayType_EndPoint, TRFOtherPlayersOnly);
+	if (TR_DidHit(trace))
+	{
+		return -1;
+	}
+	*/
+	return -1; 
+}
+
+public bool AddEntities(int entity, ArrayList entities)
+{
+	entities.Push(entity);
+	return true;
+}
+
+static float IntervalDistance(float x, float x0, float x1)
+{
+	if (x0 > x1)
+	{
+		float tmp = x0;
+		x0 = x1;
+		x1 = tmp;
+	}
+	if (x < x0)
+	{
+		return x0 - x;
+	}
+	else if (x > x1)
+	{
+		return x - x1;
+	}
+	return 0.0;
+}
+// TraceRay filter for other players exclusively.
+public bool TRFOtherPlayersOnly(int entity, int contentmask, int client)
+{
+	return (0 < entity <= MaxClients) && (entity != client);
+}

--- a/addons/sourcemod/scripting/gokz-core/misc.sp
+++ b/addons/sourcemod/scripting/gokz-core/misc.sp
@@ -583,7 +583,7 @@ static void AutoJoinTeam(int client)
 
 void OnClientPreThinkPost_UseButtons(int client)
 {
-	if (GetEntProp(client, Prop_Data, "m_afButtonPressed") & IN_USE)
+	if (GOKZ_GetCoreOption(client, Option_ButtonThroughPlayers) == ButtonThroughPlayers_Enabled && GetEntProp(client, Prop_Data, "m_afButtonPressed") & IN_USE)
 	{
 		int entity = FindUseEntity(client);
 		if (entity != -1)
@@ -663,18 +663,19 @@ static int FindUseEntity(int client)
 			}
 		}
 	}
-	// This is 1.11 only.
-	/*
+	
+	int nearestEntity;
 	float nearestPoint[3];
 	float nearestDist = FLOAT_MAX;
-	ArrayList entities;
-	TR_EnumerateEntitiesSphere(eyeOrigin, 80.0, 0, AddEntities, entities);
+	ArrayList entities = new ArrayList();
+	TR_EnumerateEntitiesSphere(eyeOrigin, 80.0, 1<<5, AddEntities, entities);
 	for (int i = 0; i < entities.Length; i++)
 	{
 		char buffer[64];
 		int ent = entities.Get(i);
 		GetEntityClassname(ent, buffer, sizeof(buffer));
-		if (StrEqual("func_button", buffer, false) && GetEntProp(entity, Prop_Data, "m_spawnflags") & SF_BUTTON_USE_ACTIVATES)
+		// Check if the entity is a button and it is pressable.
+		if (StrEqual("func_button", buffer, false) && GetEntProp(ent, Prop_Data, "m_spawnflags") & SF_BUTTON_USE_ACTIVATES)
 		{
 			float point[3];
 			CalcNearestPoint(ent, eyeOrigin, point);
@@ -684,8 +685,9 @@ static int FindUseEntity(int client)
 			{
 				dir[j] = point[j] - eyeOrigin[2];
 			}
-
+			// Check the maximum angle the player can be away from the button.
 			float minimumDot = GetEntPropFloat(ent, Prop_Send, "m_flUseLookAtAngle");
+			NormalizeVector(dir, dir);
 			float dot = GetVectorDotProduct(dir, fwd);
 			if (dot < minimumDot)
 			{
@@ -699,8 +701,8 @@ static int FindUseEntity(int client)
 				if (TR_GetFraction(trace) == 1.0 || TR_GetEntityIndex(trace) == ent)
 				{
 					CopyVector(point, nearestPoint);
-					entity = ent;
 					nearestDist = dist;
+					nearestEntity = ent;
 				}
 			}
 		}
@@ -713,9 +715,8 @@ static int FindUseEntity(int client)
 	trace = TR_TraceRayFilterEx(eyeOrigin, nearestPoint, useableContents, RayType_EndPoint, TRFOtherPlayersOnly);
 	if (TR_DidHit(trace))
 	{
-		return -1;
+		return nearestEntity;
 	}
-	*/
 	return -1; 
 }
 

--- a/addons/sourcemod/scripting/include/gokz.inc
+++ b/addons/sourcemod/scripting/include/gokz.inc
@@ -41,6 +41,8 @@ enum ObsMode
 #define SPEED_NORMAL 250.0
 #define SPEED_NO_WEAPON 260.0
 #define IGNORE_JUMP_TIME 0.2 
+#define FLOAT_MAX view_as<float>(0x7F7FFFFF)
+#define SF_BUTTON_USE_ACTIVATES 1024
 stock float PLAYER_MINS[3] = {-16.0, -16.0, 0.0};
 stock float PLAYER_MAXS[3] = {16.0, 16.0, 72.0};
 stock float PLAYER_MAXS_DUCKED[3] = {16.0, 16.0, 54.0};
@@ -1000,4 +1002,59 @@ stock int GOKZGetClientFromGameMovementAddress(Address addr, int offsetCGameMove
 {
 	Address playerAddr = view_as<Address>(LoadFromAddress(view_as<Address>(view_as<int>(addr) + offsetCGameMovement_player), NumberType_Int32));
 	return GOKZGetEntityFromAddress(playerAddr);
+}
+
+/**
+ * Gets the nearest point in the oriented bounding box of an entity to a point.
+ *
+ * @param entity			Entity index.
+ * @param origin			Point's origin.
+ * @param result			Result point.
+ */
+stock void CalcNearestPoint(int entity, float origin[3], float result[3])
+{
+	float entOrigin[3], entMins[3], entMaxs[3], trueMins[3], trueMaxs[3];
+	GetEntPropVector(entity, Prop_Send, "m_vecOrigin", entOrigin);
+	GetEntPropVector(entity, Prop_Send, "m_vecMaxs", entMaxs);
+	GetEntPropVector(entity, Prop_Send, "m_vecMins", entMins);
+
+	AddVectors(entOrigin, entMins, trueMins);
+	AddVectors(entOrigin, entMaxs, trueMaxs);
+
+	for (int i = 0; i < 3; i++)
+	{
+		result[i] = FloatClamp(origin[i], trueMins[i], trueMaxs[i]);
+	}
+}
+
+/**
+ * Get the shortest distance from P to the (infinite) line through vLineA and vLineB.
+ *
+ * @param P				Point's origin.
+ * @param vLineA		Origin of the first point of the line.
+ * @param vLineB		Origin of the first point of the line.
+ * @return				The shortest distance from the point to the line.
+ */
+stock float CalcDistanceToLine(float P[3], float vLineA[3], float vLineB[3])
+{
+	float vClosest[3];
+	float vDir[3];
+	float t;
+	float delta[3];	
+	SubtractVectors(vLineB, vLineA, vDir);
+	float div = GetVectorDotProduct(vDir, vDir);
+	if (div < EPSILON)
+	{
+		t = 0.0;
+	}
+	else
+	{
+		t = (GetVectorDotProduct(vDir, P) - GetVectorDotProduct(vDir, vLineA)) / div;
+	}
+	for (int i = 0; i < 3; i++)
+	{
+		vClosest[i] = vLineA[i] + vDir[i]*t;
+	}
+	SubtractVectors(P, vClosest, delta);
+	return GetVectorLength(delta);
 }

--- a/addons/sourcemod/scripting/include/gokz/core.inc
+++ b/addons/sourcemod/scripting/include/gokz/core.inc
@@ -79,6 +79,7 @@ enum Option:
 	Option_ErrorSounds, 
 	Option_VirtualButtonIndicators, 
 	Option_TimerButtonZoneType,
+	Option_ButtonThroughPlayers,
 	OPTION_COUNT
 };
 
@@ -138,6 +139,13 @@ enum
 	TimerButtonZoneType_BothZones,
 	TIMERBUTTONZONETYPE_COUNT
 };
+
+enum
+{
+	ButtonThroughPlayers_Disabled = 0,
+	ButtonThroughPlayers_Enabled,
+	BUTTONTHROUGHPLAYERS_COUNT
+}
 
 enum
 {
@@ -347,7 +355,8 @@ stock char gC_CoreOptionNames[OPTION_COUNT][] =
 	"GOKZ - Teleport Sounds", 
 	"GOKZ - Error Sounds", 
 	"GOKZ - VB Indicators",
-	"GOKZ - Timer Button Zone Type"
+	"GOKZ - Timer Button Zone Type",
+	"GOKZ - Button Through Players"
 };
 
 stock char gC_CoreOptionDescriptions[OPTION_COUNT][] = 
@@ -359,7 +368,8 @@ stock char gC_CoreOptionDescriptions[OPTION_COUNT][] =
 	"Teleport Sounds - 0 = Disabled, 1 = Enabled", 
 	"Error Sounds - 0 = Disabled, 1 = Enabled", 
 	"Virtual Button Indicators - 0 = Disabled, 1 = Enabled",
-	"Timer Button Zone Type - 0 = Both buttons, 1 = Only end zone, 2 = Both zones"
+	"Timer Button Zone Type - 0 = Both buttons, 1 = Only end zone, 2 = Both zones",
+	"Button Through Players - 0 = Disabled, 1 = Enabled"
 };
 
 stock char gC_CoreOptionPhrases[OPTION_COUNT][] = 
@@ -371,7 +381,8 @@ stock char gC_CoreOptionPhrases[OPTION_COUNT][] =
 	"Options Menu - Teleport Sounds", 
 	"Options Menu - Error Sounds", 
 	"Options Menu - Virtual Button Indicators",
-	"Options Menu - Timer Button Zone Type"
+	"Options Menu - Timer Button Zone Type",
+	"Options Menu - Button Through Players"
 };
 
 stock char gC_TimerButtonZoneTypePhrases[TIMERBUTTONZONETYPE_COUNT][] = 
@@ -390,7 +401,8 @@ stock int gI_CoreOptionCounts[OPTION_COUNT] =
 	TELEPORTSOUNDS_COUNT, 
 	ERRORSOUNDS_COUNT, 
 	VIRTUALBUTTONINDICATORS_COUNT,
-	TIMERBUTTONZONETYPE_COUNT
+	TIMERBUTTONZONETYPE_COUNT,
+	BUTTONTHROUGHPLAYERS_COUNT
 };
 
 stock int gI_CoreOptionDefaults[OPTION_COUNT] = 
@@ -402,7 +414,8 @@ stock int gI_CoreOptionDefaults[OPTION_COUNT] =
 	TeleportSounds_Disabled, 
 	ErrorSounds_Enabled, 
 	VirtualButtonIndicators_Disabled,
-	TimerButtonZoneType_BothButtons
+	TimerButtonZoneType_BothButtons,
+	ButtonThroughPlayers_Enabled
 };
 
 stock char gC_ModeCVars[MODECVAR_COUNT][] = 

--- a/addons/sourcemod/translations/gokz-core.phrases.txt
+++ b/addons/sourcemod/translations/gokz-core.phrases.txt
@@ -289,7 +289,10 @@
 	{
 		"en"		"Timer button/zone type"
 	}
-
+	"Options Menu - Button Through Players"
+	{
+		"en"		"Press button through players"
+	}
 
 	// =====[ OPTION PHRASES ]=====
 	"Timer Button Zone Type - Both Buttons"

--- a/cfg/sourcemod/gokz/options_menu_sorting.cfg
+++ b/cfg/sourcemod/gokz/options_menu_sorting.cfg
@@ -20,6 +20,7 @@
 		"item"		"GOKZ DB - Auto Load Timer Setup"
 		"item"		"GOKZ - Timer Button Zone Type"
 		"item"		"GOKZ QT - Map Sounds"
+		"item"		"GOKZ - Button Through Players"
 	}
 	"HUD"
 	{


### PR DESCRIPTION
Partially resolves issue #138, requires #359 to be merged.

There are two ways player can press a button, either through a direct trace to the button or a sphere around the player’s eyes. This now contains both trace methods, the sphere method would be commented out until GOKZ is updated to use SourceMod 1.11.