### PR TITLE
Use server sided footsteps

### DIFF
--- a/cfg/sourcemod/gokz/gokz.cfg
+++ b/cfg/sourcemod/gokz/gokz.cfg
@@ -53,7 +53,7 @@ mp_ignore_round_win_conditions 1
 mp_match_end_changelevel 1
 sv_ignoregrenaderadio 1
 sv_disable_radar 1
-mp_footsteps_serverside 0
+mp_footsteps_serverside 1
 sv_mincmdrate 128
 sv_minupdaterate 128
 mp_warmuptime_all_players_connected 0


### PR DESCRIPTION
Server sided footsteps are more consistent, also replay bots make no sound climbing ladder without this change.