### PR TITLE
Update JS tips to reflect new commands

### DIFF
--- a/addons/sourcemod/translations/gokz-tips-jumpstats.phrases.txt
+++ b/addons/sourcemod/translations/gokz-tips-jumpstats.phrases.txt
@@ -1,9 +1,13 @@
 "Phrases"
 {
+	"!jso"
+	{
+		"en"		"{grey}Want to filter out some of the jumpstats spam? Type {default}!jso {grey}to change your jumpstats options!"
+		"chi"		"{grey}在聊天框中输入 {default}!jso {grey}查看起跳数据!"
+		"ru"		"{grey}Хотите отфлитровать некоторые сообщения об статистике прыжков? Напишите {default}!jso {grey}для смены параметров оповещения статистики прыжков."
+	}
 	"!jumpstats"
 	{
-		"en"		"{grey}Want to filter out some of the jumpstats spam? Type {default}!jumpstats{grey}/{default}!js {grey}to change your jumpstats options!"
-		"chi"		"{grey}在聊天框中输入 {default}!jumpstats{grey}/{default}!js {grey}查看起跳数据!"
-		"ru"		"{grey}Хотите отфлитровать некоторые сообщения об статистике прыжков? Напишите {default}!jumpstats{grey}/{default}!js {grey}для смены параметров оповещения статистики прыжков."
+		"en"		"{grey}Curious about your jumpstat records? {default}!jumpstats{grey}/{default}!js {grey}will show your personal bests."
 	}
 }


### PR DESCRIPTION
Previously the !jumpstats command was a shortcut to the jumpstats
options. This has changed, and it now opens a menu that shows your
current JS records.