### PR TITLE
Fix weirdjump real perf height being higher in SKZ

### DIFF
--- a/addons/sourcemod/scripting/gokz-mode-simplekz.sp
+++ b/addons/sourcemod/scripting/gokz-mode-simplekz.sp
@@ -539,9 +539,9 @@ public void Movement_OnStopTouchGround(int client)
 void NerfRealPerf(KZPlayer player, float origin[3])
 {
 	// Not worth worrying about if player is already falling
-	// player.VerticalVelocity is not updated yet! Use takeoff velocity.
+	// player.VerticalVelocity is not updated yet! Use processing velocity.
 	float velocity[3];
-	player.GetTakeoffVelocity(velocity);
+	Movement_GetProcessingVelocity(player.ID, velocity);
 	if (velocity[2] < EPSILON)
 	{
 		return;


### PR DESCRIPTION
TakeoffVelocity is defined in OnJumpPost, but we are nerfing the height during OnJumpPre. This should be easily resolved by getting the current velocity during movement processing instead.