### PR TITLE
Prevent SQL errors due to ONLY_FULL_GROUP_BY

### DIFF
--- a/addons/sourcemod/scripting/gokz-localranks/db/sql.sp
+++ b/addons/sourcemod/scripting/gokz-localranks/db/sql.sp
@@ -387,10 +387,9 @@ SELECT b.JumpID, b.JumpType, b.Distance, b.Strafes, b.Sync, b.Pre, b.Max, b.Airt
         SELECT a.SteamID32, a.Mode, a.JumpType, MAX(a.Distance) Distance \
         FROM Jumpstats a \
         WHERE a.SteamID32=%d AND a.Mode=%d AND NOT a.IsBlockJump \
-        GROUP BY a.JumpType \
+        GROUP BY a.JumpType, a.Mode, a.SteamID32 \
     ) a ON a.JumpType=b.JumpType AND a.Distance=b.Distance \
     WHERE a.SteamID32=b.SteamID32 AND a.Mode=b.Mode AND NOT b.IsBlockJump \
-    GROUP BY b.JumpType \
     ORDER BY b.JumpType";
 
 char sql_jumpstats_getblockpbs[] = "\
@@ -403,11 +402,10 @@ SELECT c.JumpID, c.JumpType, c.Block, c.Distance, c.Strafes, c.Sync, c.Pre, c.Ma
             SELECT a.SteamID32, a.Mode, a.JumpType, MAX(a.Block) Block \
             FROM Jumpstats a \
             WHERE a.SteamID32=%d AND a.Mode=%d AND a.IsBlockJump \
-            GROUP BY a.JumpType \
+            GROUP BY a.JumpType, a.Mode, a.SteamID32 \
         ) a ON a.JumpType=b.JumpType AND a.Block=b.Block \
         WHERE a.SteamID32=b.SteamID32 AND a.Mode=b.Mode AND b.IsBlockJump \
-        GROUP BY b.JumpType \
+        GROUP BY a.JumpType, a.Mode, a.SteamID32, a.Block \
     ) b ON b.JumpType=c.JumpType AND b.Block=c.Block AND b.Distance=c.Distance \
     WHERE b.SteamID32=c.SteamID32 AND b.Mode=c.Mode AND c.IsBlockJump \
-    GROUP BY c.JumpType \
     ORDER BY c.JumpType";


### PR DESCRIPTION
When ONLY_FULL_GROUP_BY is set on the SQL server, the queries before this
change failed with an error. The ONLY_FULL_GROUP_BY mode is set by
default on new MySQL installations at least, so we could assume that
this will happen more and more as time goes by.

This fix adds missing columns to the group bys that are in the inner
queries. It also removes the group by from the outer most one, as we
have already grouped the results earlier, and there should be no need to
do it again.

As a disclaimer though, I am not a SQL wizard, and there might be some
edge-cases where this could break..? Maybe?

Fixes #275.