### PR TITLE
[gokz-profile] Fix stale tags being usable

### DIFF
--- a/addons/sourcemod/scripting/gokz-profile.sp
+++ b/addons/sourcemod/scripting/gokz-profile.sp
@@ -268,9 +268,9 @@ void UpdateTags(int client, int rank, int mode)
 	}
 }
 
-bool CanUseTagType(int client, int desiredType)
+bool CanUseTagType(int client, int tagType)
 {
-	switch (desiredType)
+	switch (tagType)
 	{
 		case ProfileTagType_Rank: return true;
 		case ProfileTagType_VIP: return CheckCommandAccess(client, "gokz_flag_vip", ADMFLAG_CUSTOM1);
@@ -281,13 +281,13 @@ bool CanUseTagType(int client, int desiredType)
 
 int GetAvailableTagTypeOrDefault(int client)
 {
-	int desiredType = GOKZ_GetOption(client, gC_ProfileOptionNames[ProfileOption_TagType]);
-	if (!CanUseTagType(client, desiredType))
+	int tagType = GOKZ_GetOption(client, gC_ProfileOptionNames[ProfileOption_TagType]);
+	if (!CanUseTagType(client, tagType))
 	{
 		return ProfileTagType_Rank;
 	}
 
-	return desiredType;
+	return tagType;
 }
 
 // =====[ COMMANDS ]=====

--- a/addons/sourcemod/scripting/gokz-profile.sp
+++ b/addons/sourcemod/scripting/gokz-profile.sp
@@ -96,6 +96,18 @@ public void OnLibraryRemoved(const char[] name)
 
 // =====[ EVENTS ]=====
 
+public void OnRebuildAdminCache(AdminCachePart part)
+{
+	for (int client = 1; client <= MaxClients; client++)
+	{
+		if (IsValidClient(client) && !IsFakeClient(client))
+		{
+			int mode = GOKZ_GetCoreOption(client, Option_Mode);
+			UpdateRank(client, mode);
+		}
+	}
+}
+
 public void GOKZ_OnOptionsMenuCreated(TopMenu topMenu)
 {
 	OnOptionsMenuCreated_OptionsMenu(topMenu);
@@ -157,13 +169,13 @@ public void UpdateRank(int client, int mode)
 	{
 		return;
 	}
-	
-	int tagType = GOKZ_GetOption(client, gC_ProfileOptionNames[ProfileOption_TagType]);
-	
+
+	int tagType = GetAvailableTagTypeOrDefault(client);
+
 	if (tagType != ProfileTagType_Rank)
 	{
 		char clanTag[64], chatTag[32], color[64];
-		
+
 		if (tagType == ProfileTagType_Admin)
 		{
 			FormatEx(clanTag, sizeof(clanTag), "[%s %T]", gC_ModeNamesShort[mode], "Tag - Admin", client);
@@ -176,13 +188,13 @@ public void UpdateRank(int client, int mode)
 			FormatEx(chatTag, sizeof(chatTag), "%T", "Tag - VIP", client);
 			color = TAG_COLOR_VIP;
 		}
-		
+
 		if (GOKZ_GetOption(client, gC_ProfileOptionNames[ProfileOption_ShowRankClanTag]) != ProfileOptionBool_Enabled)
 		{
 			FormatEx(clanTag, sizeof(clanTag), "[%s]", gC_ModeNamesShort[mode]);
 		}
 		CS_SetClientClanTag(client, clanTag);
-		
+
 		if (gB_Chat)
 		{
 			if (GOKZ_GetOption(client, gC_ProfileOptionNames[ProfileOption_ShowRankChat]) == ProfileOptionBool_Enabled)
@@ -196,7 +208,7 @@ public void UpdateRank(int client, int mode)
 		}
 		return;
 	}
-	
+
 	int points = GOKZ_GL_GetRankPoints(client, mode);
 	int rank;
 	for (rank = 1; rank < RANK_COUNT; rank++)
@@ -207,7 +219,7 @@ public void UpdateRank(int client, int mode)
 		}
 	}
 	rank--;
-	
+
 	if (GOKZ_GetCoreOption(client, Option_Mode) == mode)
 	{
 		if (points == -1)
@@ -219,7 +231,7 @@ public void UpdateRank(int client, int mode)
 			UpdateTags(client, rank, mode);
 		}
 	}
-	
+
 	if (gI_Rank[client][mode] != rank)
 	{
 		gI_Rank[client][mode] = rank;
@@ -241,7 +253,7 @@ void UpdateTags(int client, int rank, int mode)
 		FormatEx(str, sizeof(str), "[%s]", gC_ModeNamesShort[mode]);
 		CS_SetClientClanTag(client, str);
 	}
-	
+
 	if (gB_Chat)
 	{
 		if (rank != -1 &&
@@ -256,7 +268,27 @@ void UpdateTags(int client, int rank, int mode)
 	}
 }
 
+bool CanUseTagType(int client, int desiredType)
+{
+	switch (desiredType)
+	{
+		case ProfileTagType_Rank: return true;
+		case ProfileTagType_VIP: return CheckCommandAccess(client, "gokz_flag_vip", ADMFLAG_CUSTOM1);
+		case ProfileTagType_Admin: return CheckCommandAccess(client, "gokz_flag_admin", ADMFLAG_GENERIC);
+		default: return false;
+	}
+}
 
+int GetAvailableTagTypeOrDefault(int client)
+{
+	int desiredType = GOKZ_GetOption(client, gC_ProfileOptionNames[ProfileOption_TagType]);
+	if (!CanUseTagType(client, desiredType))
+	{
+		return ProfileTagType_Rank;
+	}
+
+	return desiredType;
+}
 
 // =====[ COMMANDS ]=====
 

--- a/addons/sourcemod/scripting/gokz-profile/options.sp
+++ b/addons/sourcemod/scripting/gokz-profile/options.sp
@@ -109,34 +109,19 @@ public void TopMenuHandler_Profile(TopMenu topmenu, TopMenuAction action, TopMen
 	else if (action == TopMenuAction_SelectOption)
 	{
 		GOKZ_CycleOption(param, gC_ProfileOptionNames[option]);
+
 		if (option == ProfileOption_TagType)
 		{
-			for(;;)
+			for (int i = 0; i < PROFILETAGTYPE_COUNT; i++)
 			{
-				switch (GOKZ_GetOption(param, gC_ProfileOptionNames[option]))
+				int tagType = GOKZ_GetOption(param, gC_ProfileOptionNames[option]);
+				if (!CanUseTagType(param, tagType))
 				{
-					case ProfileTagType_Rank:
-					{
-						break;
-					}
-					case ProfileTagType_Admin:
-					{
-						if (CheckCommandAccess(param, "gokz_flag_admin", ADMFLAG_GENERIC))
-						{
-							break;
-						}
-					}
-					case ProfileTagType_VIP:
-					{
-						if (CheckCommandAccess(param, "gokz_flag_vip", ADMFLAG_CUSTOM1))
-						{
-							break;
-						}
-					}
+					GOKZ_CycleOption(param, gC_ProfileOptionNames[option]);
 				}
-				GOKZ_CycleOption(param, gC_ProfileOptionNames[option]);
 			}
 		}
+
 		gTM_Options.Display(param, TopMenuPosition_LastCategory);
 	}
 }


### PR DESCRIPTION
The goal of this pull request is to prevent the following edge cases:
1. Clientprefs might be shared between multiple servers and permissions differ among them, allowing you to set an "ADMIN" tag on  server 1 and have it be shown on server 2.
2. Prevent tags with permissions tied to them being visible if permissions are not met, this pull request defaults to showing the rank if their tag type is set to an option that they cannot access.

It should be noted that this does not override the saved option value when the client cannot access the tag type.
This behaviour allows for players to set "ADMIN" tag on a server they're an admin on, and persist that option even if they join another server that shares the clientprefs, but instead have their "RANK" tag being shown.