### PR TITLE
Prevent server console spam from run invalidation

### DIFF
--- a/addons/sourcemod/scripting/gokz-core/natives.sp
+++ b/addons/sourcemod/scripting/gokz-core/natives.sp
@@ -41,6 +41,7 @@ void CreateNatives()
 	CreateNative("GOKZ_SetValidJumpOrigin", Native_SetValidJumpOrigin);
 	
 	CreateNative("GOKZ_GetTimerRunning", Native_GetTimerRunning);
+	CreateNative("GOKZ_GetValidTimer", Native_GetValidTimer);
 	CreateNative("GOKZ_GetCourse", Native_GetCourse);
 	CreateNative("GOKZ_SetCourse", Native_SetCourse);
 	CreateNative("GOKZ_GetPaused", Native_GetPaused);
@@ -352,6 +353,11 @@ public int Native_SetValidJumpOrigin(Handle plugin, int numParams)
 public int Native_GetTimerRunning(Handle plugin, int numParams)
 {
 	return view_as<int>(GetTimerRunning(GetNativeCell(1)));
+}
+
+public int Native_GetValidTimer(Handle plugin, int numParams)
+{
+	return view_as<int>(GetValidTimer(GetNativeCell(1)));
 }
 
 public int Native_GetCourse(Handle plugin, int numParams)

--- a/addons/sourcemod/scripting/gokz-core/timer/timer.sp
+++ b/addons/sourcemod/scripting/gokz-core/timer/timer.sp
@@ -15,6 +15,11 @@ bool GetTimerRunning(int client)
 	return timerRunning[client];
 }
 
+bool GetValidTimer(int client)
+{
+	return validTime[client];
+}
+
 float GetCurrentTime(int client)
 {
 	return currentTime[client];

--- a/addons/sourcemod/scripting/gokz-global.sp
+++ b/addons/sourcemod/scripting/gokz-global.sp
@@ -360,7 +360,7 @@ public Action GOKZ_OnTimerNativeCalledExternally(Handle plugin, int client)
 {
 	char pluginName[64];
 	GetPluginInfo(plugin, PlInfo_Name, pluginName, sizeof(pluginName));
-	if (GOKZ_GetTimerRunning(client))
+	if (GOKZ_GetTimerRunning(client) && GOKZ_GetValidTimer(client))
 	{
 		LogMessage("Invalidated %N's run as gokz-core native was called by \"%s\"", client, pluginName);
 	}

--- a/addons/sourcemod/scripting/gokz-global.sp
+++ b/addons/sourcemod/scripting/gokz-global.sp
@@ -360,7 +360,10 @@ public Action GOKZ_OnTimerNativeCalledExternally(Handle plugin, int client)
 {
 	char pluginName[64];
 	GetPluginInfo(plugin, PlInfo_Name, pluginName, sizeof(pluginName));
-	LogMessage("Invalidated %N's run as gokz-core native was called by \"%s\"", client, pluginName);
+	if (GOKZ_GetTimerRunning(client))
+	{
+		LogMessage("Invalidated %N's run as gokz-core native was called by \"%s\"", client, pluginName);
+	}
 	GOKZ_InvalidateRun(client);
 	return Plugin_Continue;
 }

--- a/addons/sourcemod/scripting/include/gokz/core.inc
+++ b/addons/sourcemod/scripting/include/gokz/core.inc
@@ -977,6 +977,14 @@ native void GOKZ_StopTimerAll(bool playSound = true);
 native bool GOKZ_GetTimerRunning(int client);
 
 /**
+ * Gets whether or not a player's timer is valid i.e the run is a valid run.
+ *
+ * @param client    	Client index.
+ * @return				Whether player's timer is running.
+ */
+native bool GOKZ_GetValidTimer(int client);
+
+/**
  * Gets the course a player is currently running.
  *
  * @param client    	Client index.


### PR DESCRIPTION
Every time someone uses saveloc, the run gets invalidated over and over again, leading to spam.