### PR TITLE
Require the client to be ingame to start the timer

### DIFF
--- a/addons/sourcemod/scripting/gokz-core/timer/timer.sp
+++ b/addons/sourcemod/scripting/gokz-core/timer/timer.sp
@@ -53,7 +53,8 @@ int GetCurrentTimeType(int client)
 
 bool TimerStart(int client, int course, bool allowMidair = false, bool playSound = true)
 {
-	if (!IsPlayerAlive(client)
+	if (!IsClientInGame(client)
+		 || !IsPlayerAlive(client)
 		 || JustStartedTimer(client)
 		 || JustTeleported(client)
 		 || JustNoclipped(client)


### PR DESCRIPTION
It seems like IsPlayerAlive check is not doing the trick.
Exception says it requires the player to be connected, but I figured an in-game check is better.

[SM] Exception reported: Client 3 is not connected
[SM] Blaming: gokz-replays.smx
[SM] Call stack trace:
[SM]   [0] IsFakeClient
[SM]   [1] Line 261, gokz-replays/recording.sp::StartRunRecording
