### PR TITLE
Fix options size being too short

### DIFF
--- a/addons/sourcemod/scripting/gokz-core/natives.sp
+++ b/addons/sourcemod/scripting/gokz-core/natives.sp
@@ -469,7 +469,7 @@ public int Native_SetTeleportCount(Handle plugin, int numParams)
 
 public int Native_RegisterOption(Handle plugin, int numParams)
 {
-	char name[30];
+	char name[GOKZ_OPTION_MAX_NAME_LENGTH];
 	GetNativeString(1, name, sizeof(name));
 	char description[255];
 	GetNativeString(2, description, sizeof(description));
@@ -478,7 +478,7 @@ public int Native_RegisterOption(Handle plugin, int numParams)
 
 public int Native_GetOptionProp(Handle plugin, int numParams)
 {
-	char option[30];
+	char option[GOKZ_OPTION_MAX_NAME_LENGTH];
 	GetNativeString(1, option, sizeof(option));
 	OptionProp prop = GetNativeCell(2);
 	any value = GetOptionProp(option, prop);
@@ -494,7 +494,7 @@ public int Native_GetOptionProp(Handle plugin, int numParams)
 
 public int Native_SetOptionProp(Handle plugin, int numParams)
 {
-	char option[30];
+	char option[GOKZ_OPTION_MAX_NAME_LENGTH];
 	GetNativeString(1, option, sizeof(option));
 	OptionProp prop = GetNativeCell(2);
 	return SetOptionProp(option, prop, GetNativeCell(3));
@@ -502,14 +502,14 @@ public int Native_SetOptionProp(Handle plugin, int numParams)
 
 public int Native_GetOption(Handle plugin, int numParams)
 {
-	char option[30];
+	char option[GOKZ_OPTION_MAX_NAME_LENGTH];
 	GetNativeString(2, option, sizeof(option));
 	return view_as<int>(GetOption(GetNativeCell(1), option));
 }
 
 public int Native_SetOption(Handle plugin, int numParams)
 {
-	char option[30];
+	char option[GOKZ_OPTION_MAX_NAME_LENGTH];
 	GetNativeString(2, option, sizeof(option));
 	return view_as<int>(SetOption(GetNativeCell(1), option, GetNativeCell(3)));
 }

--- a/addons/sourcemod/scripting/gokz-core/options.sp
+++ b/addons/sourcemod/scripting/gokz-core/options.sp
@@ -12,14 +12,14 @@ bool RegisterOption(const char[] name, const char[] description, OptionType type
 		LogError("Failed to register option \"%s\" due to invalid default value and value range.", name);
 		return false;
 	}
-	
-	if (strlen(name) > GOKZ_OPTION_MAX_NAME_LENGTH - 1)
+
+	if (strlen(name) > GOKZ_OPTION_MAX_NAME_LENGTH)
 	{
 		LogError("Failed to register option \"%s\" because its name is too long.", name);
 		return false;
 	}
 	
-	if (strlen(name) > GOKZ_OPTION_MAX_NAME_LENGTH - 1)
+	if (strlen(description) > GOKZ_OPTION_MAX_DESC_LENGTH)
 	{
 		LogError("Failed to register option \"%s\" because its description is too long.", name);
 		return false;


### PR DESCRIPTION
The menu option breaks if you register an option between 30 and 50 characters.
Also the description check was incorrect.