### PR TITLE
Fix forced team pick being run too early

### DIFF
--- a/addons/sourcemod/scripting/gokz-core/misc.sp
+++ b/addons/sourcemod/scripting/gokz-core/misc.sp
@@ -211,13 +211,27 @@ static bool savedOnLadder[MAXPLAYERS + 1];
 
 void OnClientPutInServer_JoinTeam(int client)
 {
-	// After OnClientPutInServer, player is moved to the origin of a point_viewcontrol entity.
-	// We need to wait one tick before assign the player's team and teleport them to a valid spawn.
-	if (!IsFakeClient(client))
-	{
-		RequestFrame(AutoJoinTeam, client);
-	}
+	// Automatically put the player on a team if he doesn't choose one.
+	// The mp_force_pick_time convar is the built in way to do this, but that obviously
+	// does not call GOKZ_JoinTeam which includes a fix for spawning in the void when
+	// there is no valid spawns available. 
+	CreateTimer(12.0, Timer_ForceJoinTeam, GetClientUserId(client), TIMER_FLAG_NO_MAPCHANGE);
+
 	hasSavedPosition[client] = false;
+}
+
+public Action Timer_ForceJoinTeam(Handle timer, int userid)
+{
+    int client = GetClientOfUserId(userid);
+    if (IsValidClient(client))
+    {
+        int team = GetClientTeam(client);
+        if (team == CS_TEAM_NONE)
+        {
+            GOKZ_JoinTeam(client, CS_TEAM_SPECTATOR, false);
+        }
+    }
+    return Plugin_Stop;
 }
 
 void OnTimerStart_JoinTeam(int client)
@@ -238,10 +252,14 @@ void JoinTeam(int client, int newTeam, bool restorePos)
 	
 	if (newTeam == CS_TEAM_SPECTATOR && currentTeam != CS_TEAM_SPECTATOR)
 	{
-		player.GetOrigin(savedOrigin[client]);
-		player.GetEyeAngles(savedAngles[client]);
-		savedOnLadder[client] = player.Movetype == MOVETYPE_LADDER;
-		hasSavedPosition[client] = true;
+		if (currentTeam != CS_TEAM_NONE)
+		{
+			player.GetOrigin(savedOrigin[client]);
+			player.GetEyeAngles(savedAngles[client]);
+			savedOnLadder[client] = player.Movetype == MOVETYPE_LADDER;
+			hasSavedPosition[client] = true;
+		}
+
 		if (!player.Paused && !player.CanPause)
 		{
 			player.StopTimer();
@@ -510,10 +528,4 @@ void OnMapStart_FixMissingSpawns()
 			TeleportEntity(newSpawn, origin, angles, NULL_VECTOR);
 		}
 	}
-}
-
-static void AutoJoinTeam(int client)
-{
-	int team = GetRandomInt(CS_TEAM_T, CS_TEAM_CT);
-	JoinTeam(client, team, false);
 }

--- a/cfg/sourcemod/gokz/gokz.cfg
+++ b/cfg/sourcemod/gokz/gokz.cfg
@@ -58,5 +58,8 @@ sv_mincmdrate 128
 sv_minupdaterate 128
 mp_warmuptime_all_players_connected 0
 
+// Team picking
+mp_force_pick_time 60
+
 // Restart round to ensure settings (e.g. mp_weapons_allow_map_placed) are applied
 mp_restartgame 1


### PR DESCRIPTION
This was causing client-sided animation sequences to be messed up until a full-update happened.
I also changed the forced team to spectator to reduce AFK players blocking timers on maps with timers close to spawn points.
