### PR TITLE
Improve replay bot name and clantags

### DIFF
--- a/addons/sourcemod/scripting/gokz-replays/playback.sp
+++ b/addons/sourcemod/scripting/gokz-replays/playback.sp
@@ -1187,10 +1187,7 @@ static void SetBotClanTag(int bot)
 
 static void SetBotName(int bot)
 {
-	int client = botClient[bot];
 	char name[MAX_NAME_LENGTH];
-
-	gB_HideNameChange = true;
 
 	if (botReplayType[bot] == ReplayType_Run)
 	{
@@ -1220,7 +1217,8 @@ static void SetBotName(int bot)
 			botAlias[bot]);
 	}
 	
-	SetClientName(client, name);
+	gB_HideNameChange = true;
+	SetClientName(botClient[bot], name);
 }
 
 // Returns the number of bots that are currently replaying

--- a/addons/sourcemod/scripting/gokz-replays/playback.sp
+++ b/addons/sourcemod/scripting/gokz-replays/playback.sp
@@ -30,6 +30,9 @@ static bool botPaused[RP_MAX_BOTS];
 static bool botPlaybackPaused[RP_MAX_BOTS];
 static int botKnife[RP_MAX_BOTS];
 static int botWeapon[RP_MAX_BOTS];
+static int botJumpType[RP_MAX_BOTS];
+static float botJumpDistance[RP_MAX_BOTS];
+static int botJumpBlockDistance[RP_MAX_BOTS];
 
 static int timeOnGround[RP_MAX_BOTS];
 static int timeInAir[RP_MAX_BOTS];
@@ -559,16 +562,13 @@ static bool LoadFormatVersion2Replay(File file, int client, int bot)
 		case ReplayType_Jump:
 		{
 			// Jump Type
-			int jumpType;
-			file.ReadInt8(jumpType);
+			file.ReadInt8(botJumpType[bot]);
 
 			// Distance
-			float distance;
-			file.ReadInt32(view_as<int>(distance));
+			file.ReadInt32(view_as<int>(botJumpDistance[bot]));
 
 			// Block Distance
-			int blockDistance;
-			file.ReadInt32(blockDistance);
+			file.ReadInt32(botJumpBlockDistance[bot]);
 
 			// Strafe Count
 			int strafeCount;
@@ -595,7 +595,7 @@ static bool LoadFormatVersion2Replay(File file, int client, int bot)
 
 			// Finish spit to console
 			PrintToConsole(client, "Jump Type: %s\nJump Distance: %f\nBlock Distance: %d\nStrafe Count: %d\nSync: %f\n Pre: %f\nMax: %f\nAirtime: %d", 
-				gC_JumpTypes[jumpType], distance, blockDistance, strafeCount, sync, pre, max, airtime);
+				gC_JumpTypes[botJumpType[bot]], botJumpDistance[bot], botJumpBlockDistance[bot], strafeCount, sync, pre, max, airtime);
 		}
 	}
 
@@ -1092,28 +1092,13 @@ static void SetBotStuff(int bot)
 	GOKZ_SetCoreOption(client, Option_Mode, botMode[bot]);
 	GOKZ_SetCoreOption(client, Option_Style, botStyle[bot]);
 	
-	// Set bot clan tag
-	char tag[MAX_NAME_LENGTH];
-	if (botCourse[bot] == 0)
-	{  // Main course so tag "MODE NUB/PRO"
-		FormatEx(tag, sizeof(tag), "%s %s", 
-			gC_ModeNamesShort[botMode[bot]], gC_TimeTypeNames[GOKZ_GetTimeTypeEx(botTeleportsUsed[bot])]);
-	}
-	else
-	{  // Bonus course so tag "MODE B# NUB/PRO"
-		FormatEx(tag, sizeof(tag), "%s B%d %s", 
-			gC_ModeNamesShort[botMode[bot]], botCourse[bot], gC_TimeTypeNames[GOKZ_GetTimeTypeEx(botTeleportsUsed[bot])]);
-	}
-	CS_SetClientClanTag(client, tag);
-	
-	// Set bot name e.g. "DanZay (01:23.45)"
-	char name[MAX_NAME_LENGTH];
-	FormatEx(name, sizeof(name), "%s (%s)", botAlias[bot], GOKZ_FormatTime(botTime[bot]));
-	gB_HideNameChange = true;
-	SetClientName(client, name);
-	
+	// Clan tag and name
+	SetBotClanTag(bot);
+	SetBotName(bot);
+
 	// Set the bot's team based on if it's NUB or PRO
-	if (GOKZ_GetTimeTypeEx(botTeleportsUsed[bot]) == TimeType_Pro)
+	if (botReplayType[bot] == ReplayType_Run 
+		&& GOKZ_GetTimeTypeEx(botTeleportsUsed[bot]) == TimeType_Pro)
 	{
 		GOKZ_JoinTeam(client, CS_TEAM_CT);
 	}
@@ -1121,7 +1106,7 @@ static void SetBotStuff(int bot)
 	{
 		GOKZ_JoinTeam(client, CS_TEAM_T);
 	}
-	
+
 	// Set bot weapons
 	// Always start by removing the pistol and knife
 	int currentPistol = GetPlayerWeaponSlot(client, CS_SLOT_SECONDARY);
@@ -1163,6 +1148,79 @@ static void SetBotStuff(int bot)
 	}
 
 	botCurrentTeleport[bot] = 0;
+}
+
+static void SetBotClanTag(int bot)
+{
+	char tag[MAX_NAME_LENGTH];
+
+	if (botReplayType[bot] == ReplayType_Run)
+	{
+		if (botCourse[bot] == 0)
+		{
+			// KZT PRO
+			FormatEx(tag, sizeof(tag), "%s %s", 
+				gC_ModeNamesShort[botMode[bot]], gC_TimeTypeNames[GOKZ_GetTimeTypeEx(botTeleportsUsed[bot])]);
+		}
+		else
+		{
+			// KZT B2 PRO
+			FormatEx(tag, sizeof(tag), "%s B%d %s", 
+				gC_ModeNamesShort[botMode[bot]], botCourse[bot], gC_TimeTypeNames[GOKZ_GetTimeTypeEx(botTeleportsUsed[bot])]);
+		}
+	}
+	else if (botReplayType[bot] == ReplayType_Jump)
+	{
+		// KZT LJ
+		FormatEx(tag, sizeof(tag), "%s %s",
+			gC_ModeNamesShort[botMode[bot]], gC_JumpTypesShort[botJumpType[bot]]);
+	}
+	else
+	{
+		// KZT
+		FormatEx(tag, sizeof(tag), "%s", 
+			gC_ModeNamesShort[botMode[bot]]);
+	}
+
+	CS_SetClientClanTag(botClient[bot], tag);
+}
+
+static void SetBotName(int bot)
+{
+	int client = botClient[bot];
+	char name[MAX_NAME_LENGTH];
+
+	gB_HideNameChange = true;
+
+	if (botReplayType[bot] == ReplayType_Run)
+	{
+		// DanZay (01:23.45)
+		FormatEx(name, sizeof(name), "%s (%s)", 
+			botAlias[bot], GOKZ_FormatTime(botTime[bot]));
+	}
+	else if (botReplayType[bot] == ReplayType_Jump)
+	{
+		if (botJumpBlockDistance[bot] == 0)
+		{
+			// DanZay (291.44)
+			FormatEx(name, sizeof(name), "%s (%.2f)", 
+				botAlias[bot], botJumpDistance[bot]);
+		}
+		else
+		{
+			// DanZay (291.44 on 289 block)
+			FormatEx(name, sizeof(name), "%s (%.2f on %d block)", 
+				botAlias[bot], botJumpDistance[bot], botJumpBlockDistance[bot]);
+		}
+	}
+	else
+	{
+		// DanZay
+		FormatEx(name, sizeof(name), "%s", 
+			botAlias[bot]);
+	}
+	
+	SetClientName(client, name);
 }
 
 // Returns the number of bots that are currently replaying


### PR DESCRIPTION
Run replays display is unchanged
Jump replays now display as `KZT LJ BOT Szwagi (271.23)` or `KZT LJ BOT Szwagi (271.23 on 270 block)`

Jump replays bots only join the T team now, before it was based on leftover state of teleport count.
