### PR TITLE
Add spectator list, uses menu for replay control instead, fix replay control menu overriding other menus

### DIFF
--- a/addons/sourcemod/scripting/gokz-hud/info_panel.sp
+++ b/addons/sourcemod/scripting/gokz-hud/info_panel.sp
@@ -63,14 +63,30 @@ static bool NothingEnabledInInfoPanel(KZPlayer player)
 
 static char[] GetInfoPanel(KZPlayer player, HUDInfo info)
 {
-	char infoPanelText[320];
+	char infoPanelText[512];
 	FormatEx(infoPanelText, sizeof(infoPanelText), 
-		"<font color='#ffffff08'>%s%s%s", 
+		"<font color='#ffffff08'>%s%s%s%s",
+		GetSpectatorString(player, info),
 		GetTimeString(player, info), 
 		GetSpeedString(player, info), 
 		GetKeysString(player, info));
 	TrimString(infoPanelText);
 	return infoPanelText;
+}
+
+static char[] GetSpectatorString(KZPlayer player, HUDInfo info)
+{
+	char spectatorString[255];
+	if (player.SpectatorListPosition != SpectatorListPosition_InfoPanel || player.SpectatorList == SpectatorList_Disabled)
+	{
+		return spectatorString;
+	}
+	// Only return something if the player is alive or observing someone else
+	if (player.Alive || player.ObserverTarget != -1)
+	{
+		FormatEx(spectatorString, sizeof(spectatorString), "%s", FormatSpectatorTextForInfoPanel(player, KZPlayer(info.ID)));
+	}
+	return spectatorString;
 }
 
 static char[] GetTimeString(KZPlayer player, HUDInfo info)

--- a/addons/sourcemod/scripting/gokz-hud/menu.sp
+++ b/addons/sourcemod/scripting/gokz-hud/menu.sp
@@ -74,4 +74,15 @@ void OnJoinTeam_Menu(int client)
 void OnStartPositionSet_Menu(int client)
 {
 	CancelGOKZHUDMenu(client);
-} 
+}
+
+void OnPluginEnd_Menu()
+{
+	for (int client = 1; client <= MaxClients; client++)
+	{
+		if (IsValidClient(client))
+		{
+			CancelGOKZHUDMenu(client);
+		}
+	}
+}

--- a/addons/sourcemod/scripting/gokz-hud/natives.sp
+++ b/addons/sourcemod/scripting/gokz-hud/natives.sp
@@ -1,0 +1,28 @@
+
+// =====[ NATIVES ]=====
+
+void CreateNatives()
+{
+	CreateNative("GOKZ_HUD_GetMenuShowing", Native_GetMenuShowing);
+	CreateNative("GOKZ_HUD_SetMenuShowing", Native_SetMenuShowing);
+	CreateNative("GOKZ_HUD_GetMenuSpectatorText", Native_GetSpectatorText);
+}
+
+public int Native_GetMenuShowing(Handle plugin, int numParams)
+{
+	return view_as<int>(gB_MenuShowing[GetNativeCell(1)]);
+}
+
+public int Native_SetMenuShowing(Handle plugin, int numParams)
+{
+	gB_MenuShowing[GetNativeCell(1)] = view_as<bool>(GetNativeCell(2));
+}
+
+public int Native_GetSpectatorText(Handle plugin, int numParams)
+{
+	HUDInfo info;
+	GetNativeArray(2, info, sizeof(HUDInfo));
+	KZPlayer player = KZPlayer(GetNativeCell(1));
+	FormatNativeString(3, 0, 0, GetNativeCell(4), _, "", FormatSpectatorTextForMenu(player, info));
+	return 1;
+}

--- a/addons/sourcemod/scripting/gokz-hud/options_menu.sp
+++ b/addons/sourcemod/scripting/gokz-hud/options_menu.sp
@@ -120,6 +120,18 @@ public void TopMenuHandler_HUD(TopMenu topmenu, TopMenuAction action, TopMenuObj
 					gC_HUDOptionPhrases[option], param,
 					gC_ShowControlsPhrases[GOKZ_HUD_GetOption(param, option)], param);
 			}
+			case HUDOption_SpectatorList:
+			{
+				FormatEx(buffer, maxlength, "%T - %T",
+					gC_HUDOptionPhrases[option], param,
+					gC_SpectatorListPhrases[GOKZ_HUD_GetOption(param, option)], param);
+			}
+			case HUDOption_SpectatorListPosition:
+			{
+				FormatEx(buffer, maxlength, "%T - %T",
+					gC_HUDOptionPhrases[option], param,
+					gC_SpectatorListPositionPhrases[GOKZ_HUD_GetOption(param, option)], param);
+			}
 			default:FormatToggleableOptionDisplay(param, option, buffer, maxlength);
 		}
 	}

--- a/addons/sourcemod/scripting/gokz-hud/spectate_text.sp
+++ b/addons/sourcemod/scripting/gokz-hud/spectate_text.sp
@@ -1,0 +1,120 @@
+/*	
+	Responsible for spectator list on the HUD.
+*/
+
+#define SPECATATOR_LIST_MAX_COUNT 5
+
+// =====[ PUBLIC ]=====
+
+char[] FormatSpectatorTextForMenu(KZPlayer player, HUDInfo info)
+{
+	int specCount;
+	char spectatorTextString[224];
+	if (player.GetHUDOption(HUDOption_SpectatorList) >= SpectatorList_Simple)
+	{
+		for (int i = 1; i <= MaxClients; i++)
+		{
+			if (gI_ObserverTarget[i] == info.ID)
+			{
+				specCount++;
+				if (player.GetHUDOption(HUDOption_SpectatorList) == SpectatorList_Advanced)
+				{
+					char buffer[64];
+					if (specCount < SPECATATOR_LIST_MAX_COUNT)
+					{
+						GetClientName(i, buffer, sizeof(buffer));
+						Format(spectatorTextString, sizeof(spectatorTextString), "%s\n%s", spectatorTextString, buffer);
+					}
+					else if (specCount == SPECATATOR_LIST_MAX_COUNT)
+					{
+						StrCat(spectatorTextString, sizeof(spectatorTextString), "\n...");
+					}
+				}
+			}
+		}
+		if (specCount > 0)
+		{			
+			if (player.GetHUDOption(HUDOption_SpectatorList) == SpectatorList_Advanced)
+			{
+				Format(spectatorTextString, sizeof(spectatorTextString), "%t\n ", "Spectator List - Menu (Advanced)", specCount, spectatorTextString);
+			}
+			else
+			{
+				Format(spectatorTextString, sizeof(spectatorTextString), "%t\n ", "Spectator List - Menu (Simple)", specCount);
+			}
+		}
+		else
+		{
+			FormatEx(spectatorTextString, sizeof(spectatorTextString), "");
+		}
+	}
+	return spectatorTextString;
+}
+
+char[] FormatSpectatorTextForInfoPanel(KZPlayer player, KZPlayer targetPlayer)
+{
+	int specCount;
+	char spectatorTextString[160];
+	if (player.GetHUDOption(HUDOption_SpectatorList) >= SpectatorList_Simple)
+	{
+		// TODO: Make faster logic
+		for (int i = 1; i <= MaxClients; i++)
+		{
+			if (gI_ObserverTarget[i] == targetPlayer.ID)
+			{
+				specCount++;
+				if (player.GetHUDOption(HUDOption_SpectatorList) == SpectatorList_Advanced)
+				{
+					char buffer[64];
+					if (specCount < SPECATATOR_LIST_MAX_COUNT)
+					{
+						GetClientName(i, buffer, sizeof(buffer));
+						if (specCount == 1)
+						{
+							Format(spectatorTextString, sizeof(spectatorTextString), "%s", buffer);
+						}
+						else
+						{
+							Format(spectatorTextString, sizeof(spectatorTextString), "%s, %s", spectatorTextString, buffer);
+						}
+					}
+					else if (specCount == SPECATATOR_LIST_MAX_COUNT)
+					{
+						Format(spectatorTextString, sizeof(spectatorTextString), " ...");
+					}
+				}
+			}
+		}
+		if (specCount > 0)
+		{
+			if (player.GetHUDOption(HUDOption_SpectatorList) == SpectatorList_Advanced)
+			{
+				Format(spectatorTextString, sizeof(spectatorTextString), "%t\n", "Spectator List - Info Panel (Advanced)", specCount, spectatorTextString);
+			}
+			else
+			{
+				Format(spectatorTextString, sizeof(spectatorTextString), "%t\n", "Spectator List - Info Panel (Simple)", specCount);
+			}
+		}
+		else
+		{
+			FormatEx(spectatorTextString, sizeof(spectatorTextString), "");
+		}
+	}
+	return spectatorTextString;
+}
+
+void UpdateSpectatorList()
+{
+	for (int client = 1; client < MaxClients; client++)
+	{
+		if (IsValidClient(client) && !IsFakeClient(client))
+		{
+			gI_ObserverTarget[client] = GetObserverTarget(client);
+		}
+		else
+		{
+			gI_ObserverTarget[client] = -1;
+		}
+	}
+}

--- a/addons/sourcemod/scripting/gokz-hud/spectate_text.sp
+++ b/addons/sourcemod/scripting/gokz-hud/spectate_text.sp
@@ -106,7 +106,7 @@ char[] FormatSpectatorTextForInfoPanel(KZPlayer player, KZPlayer targetPlayer)
 
 void UpdateSpectatorList()
 {
-	for (int client = 1; client < MaxClients; client++)
+	for (int client = 1; client <= MaxClients; client++)
 	{
 		if (IsValidClient(client) && !IsFakeClient(client))
 		{

--- a/addons/sourcemod/scripting/gokz-hud/timer_text.sp
+++ b/addons/sourcemod/scripting/gokz-hud/timer_text.sp
@@ -16,18 +16,25 @@ static Handle timerHudSynchronizer;
 char[] FormatTimerTextForMenu(KZPlayer player, HUDInfo info)
 {
 	char timerTextString[32];
-	if (player.GetHUDOption(HUDOption_TimerType) == TimerType_Enabled)
+	if (info.TimerRunning)
 	{
-		FormatEx(timerTextString, sizeof(timerTextString), 
-			"%s %s", 
-			gC_TimeTypeNames[info.TimeType], 
-			GOKZ_HUD_FormatTime(player.ID, info.Time));
-	}
-	else
-	{
-		FormatEx(timerTextString, sizeof(timerTextString), 
-			"%s", 
-			GOKZ_HUD_FormatTime(player.ID, info.Time));
+		if (player.GetHUDOption(HUDOption_TimerType) == TimerType_Enabled)
+		{
+			FormatEx(timerTextString, sizeof(timerTextString), 
+				"%s %s", 
+				gC_TimeTypeNames[info.TimeType], 
+				GOKZ_HUD_FormatTime(player.ID, info.Time));
+		}
+		else
+		{
+			FormatEx(timerTextString, sizeof(timerTextString), 
+				"%s", 
+				GOKZ_HUD_FormatTime(player.ID, info.Time));
+		}
+		if (info.Paused)
+		{
+			Format(timerTextString, sizeof(timerTextString), "%s %T", timerTextString, "Info Panel Text - PAUSED");
+		}
 	}
 	return timerTextString;
 }
@@ -67,15 +74,6 @@ void OnTimerStopped_TimerText(int client)
 	ClearTimerText(client);
 }
 
-public int PanelHandler_Menu(Menu menu, MenuAction action, int param1, int param2)
-{
-	if (action == MenuAction_Cancel)
-	{
-		gB_MenuShowing[param1] = false;
-	}
-}
-
-
 
 // =====[ PRIVATE ]=====
 
@@ -106,36 +104,7 @@ static void ShowTimerText(KZPlayer player, HUDInfo info)
 		}
 		return;
 	}
-	
-	if (player.TimerText == TimerText_TPMenu)
-	{
-		// If there is no menu showing, or if the TP menu is currently showing;
-		// and if player is spectating, or is alive with TP menu disabled and not paused
-		
-		// Note that we don't mind if player we're spectating is paused etc. as there are too
-		// many variables to track whether we need to update the timer text for the spectator.
-		
-		if ((gB_MenuShowing[player.ID] || GetClientMenu(player.ID) == MenuSource_None)
-			 && (player.ID != info.ID || player.TPMenu == TPMenu_Disabled && !player.Paused))
-		{
-			// Use a Panel if want to show ONLY timer text (not TP menu)
-			// as it doesn't seem to be possible to display a Menu with no items.
-			Panel panel = new Panel(null);
-			panel.SetTitle(FormatTimerTextForMenu(player, info));
-			int observerTarget = GetObserverTarget(player.ID);
-			if (observerTarget != -1 && IsFakeClient(observerTarget)
-				 && info.TimeType == TimeType_Nub)
-			{
-				char text[32];
-				FormatEx(text, sizeof(text), "%t", "TP Menu - Spectator Teleports", info.CurrentTeleport);
-				panel.DrawItem(text, ITEMDRAW_RAWLINE);
-			}
-			panel.Send(player.ID, PanelHandler_Menu, MENU_TIME_FOREVER);
-			delete panel;
-			gB_MenuShowing[player.ID] = true;
-		}
-	}
-	else if (player.TimerText == TimerText_Top || player.TimerText == TimerText_Bottom)
+	if (player.TimerText == TimerText_Top || player.TimerText == TimerText_Bottom)
 	{
 		int colour[4]; // RGBA
 		if (player.GetHUDOption(HUDOption_TimerType) == TimerType_Enabled)

--- a/addons/sourcemod/scripting/gokz-hud/timer_text.sp
+++ b/addons/sourcemod/scripting/gokz-hud/timer_text.sp
@@ -33,7 +33,7 @@ char[] FormatTimerTextForMenu(KZPlayer player, HUDInfo info)
 		}
 		if (info.Paused)
 		{
-			Format(timerTextString, sizeof(timerTextString), "%s %T", timerTextString, "Info Panel Text - PAUSED");
+			Format(timerTextString, sizeof(timerTextString), "%s (%T)", timerTextString, "Info Panel Text - PAUSED", player.ID);
 		}
 	}
 	return timerTextString;

--- a/addons/sourcemod/scripting/gokz-replays.sp
+++ b/addons/sourcemod/scripting/gokz-replays.sp
@@ -35,6 +35,7 @@ public Plugin myinfo =
 
 #define UPDATER_URL GOKZ_UPDATER_BASE_URL..."gokz-replays.txt"
 
+bool gB_GOKZHUD;
 bool gB_GOKZLocalDB;
 char gC_CurrentMap[64];
 int gI_CurrentMapFileSize;
@@ -80,7 +81,8 @@ public void OnAllPluginsLoaded()
 		Updater_AddPlugin(UPDATER_URL);
 	}
 	gB_GOKZLocalDB = LibraryExists("gokz-localdb");
-	
+	gB_GOKZHUD = LibraryExists("gokz-hud");
+
 	for (int client = 1; client <= MaxClients; client++)
 	{
 		if (IsClientInGame(client))
@@ -97,11 +99,13 @@ public void OnLibraryAdded(const char[] name)
 		Updater_AddPlugin(UPDATER_URL);
 	}
 	gB_GOKZLocalDB = gB_GOKZLocalDB || StrEqual(name, "gokz-localdb");
+	gB_GOKZHUD = gB_GOKZHUD || StrEqual(name, "gokz-hud");
 }
 
 public void OnLibraryRemoved(const char[] name)
 {
 	gB_GOKZLocalDB = gB_GOKZLocalDB && !StrEqual(name, "gokz-localdb");
+	gB_GOKZHUD = gB_GOKZHUD && !StrEqual(name, "gokz-hud");
 }
 
 

--- a/addons/sourcemod/scripting/gokz-replays/api.sp
+++ b/addons/sourcemod/scripting/gokz-replays/api.sp
@@ -8,6 +8,7 @@ void CreateNatives()
 {
 	CreateNative("GOKZ_RP_GetPlaybackInfo", Native_RP_GetPlaybackInfo);
 	CreateNative("GOKZ_RP_LoadJumpReplay", Native_RP_LoadJumpReplay);
+	CreateNative("GOKZ_RP_UpdateReplayControlMenu", Native_RP_UpdateReplayControlMenu);
 }
 
 public int Native_RP_GetPlaybackInfo(Handle plugin, int numParams)
@@ -26,6 +27,11 @@ public int Native_RP_LoadJumpReplay(Handle plugin, int numParams)
 	GetNativeString(2, path, len + 1);
 	int botClient = LoadReplayBot(GetNativeCell(1), path);
 	return botClient;
+}
+
+public int Native_RP_UpdateReplayControlMenu(Handle plugin, int numParams)
+{
+	return view_as<int>(UpdateReplayControlMenu(GetNativeCell(1)));
 }
 
 // =====[ FORWARDS ]=====

--- a/addons/sourcemod/scripting/gokz-replays/controls.sp
+++ b/addons/sourcemod/scripting/gokz-replays/controls.sp
@@ -2,6 +2,10 @@
 	Lets player control the replay bot.
 */
 
+#define ITEM_INFO_PAUSE "pause"
+#define ITEM_INFO_SKIP "skip"
+#define ITEM_INFO_REWIND "rewind"
+#define ITEM_INFO_FREECAM "freecam"
 
 static int controllingPlayer[RP_MAX_BOTS];
 static int botTeleports[RP_MAX_BOTS];
@@ -13,24 +17,25 @@ static bool showReplayControls[MAXPLAYERS + 1];
 
 void OnPlayerRunCmdPost_ReplayControls(int client, int cmdnum)
 {
-	if (cmdnum % 6 == 3)
+	// Let the HUD plugin takes care of this if possible.
+	if (cmdnum % 6 == 3 && !gB_GOKZHUD)
 	{
 		UpdateReplayControlMenu(client);
 	}
 }
 
-void UpdateReplayControlMenu(int client)
+bool UpdateReplayControlMenu(int client)
 {
 	if (!IsValidClient(client) || IsFakeClient(client))
 	{
-		return;
+		return false;
 	}
 	
 	int botClient = GetObserverTarget(client);
 	int bot = GetBotFromClient(botClient);
 	if (bot == -1)
 	{
-		return;
+		return false;
 	}
 	
 	if (!IsReplayBotControlled(bot, botClient) && !InBreather(bot))
@@ -40,73 +45,88 @@ void UpdateReplayControlMenu(int client)
 	}
 	else if (controllingPlayer[bot] != client)
 	{
-		return;
+		return false;
 	}
 	
-	if (showReplayControls[client] &&
+	if (showReplayControls[client] &&	
 		GOKZ_HUD_GetOption(client, HUDOption_ShowControls) == ReplayControls_Enabled &&
-		(GetClientMenu(client) == MenuSource_None ||
-		 GetClientAvgLoss(client, NetFlow_Both) > EPSILON || 
-		 GOKZ_HUD_GetOption(client, HUDOption_TimerText) == TimerText_TPMenu))
+		(GetClientMenu(client) == MenuSource_None || 
+			GOKZ_HUD_GetMenuShowing(client) && GetClientAvgLoss(client, NetFlow_Both) > EPSILON || 
+			GOKZ_HUD_GetMenuShowing(client) && GOKZ_HUD_GetOption(client, HUDOption_TimerText) == TimerText_TPMenu))
 	{
 		botTeleports[bot] = PlaybackGetTeleports(bot);
 		ShowReplayControlMenu(client, bot);
+		return true;
 	}
+	return false;
 }
 
 void ShowReplayControlMenu(int client, int bot)
 {
-	char text[32];
+	char text[256];
 	
-	Panel panel = new Panel();
-	
-	if (GOKZ_HUD_GetOption(client, HUDOption_TimerText) == TimerText_TPMenu)
+	Menu menu = new Menu(MenuHandler_ReplayControls);
+	menu.OptionFlags = MENUFLAG_NO_SOUND;
+	menu.Pagination = MENU_NO_PAGINATION;
+	menu.ExitButton = true;
+	if (gB_GOKZHUD)
 	{
-		FormatEx(text, sizeof(text), "%T - %s", "Replay Controls - Title", client,
-			GOKZ_FormatTime(GetPlaybackTime(bot), GOKZ_HUD_GetOption(client, HUDOption_TimerStyle) == TimerStyle_Precise));
-		panel.SetTitle(text);
+		if (GOKZ_HUD_GetOption(client, HUDOption_SpectatorList) != SpectatorList_Disabled &&
+			GOKZ_HUD_GetOption(client, HUDOption_SpectatorListPosition) == SpectatorListPosition_TPMenu)
+		{
+			HUDInfo info;
+			GetPlaybackState(client, info);
+			GOKZ_HUD_GetMenuSpectatorText(client, info, text, sizeof(text));
+			PrintToConsole(client, text);
+		}
+		if (GOKZ_HUD_GetOption(client, HUDOption_TimerText) == TimerText_TPMenu)
+		{
+			Format(text, sizeof(text), "%s\n%T - %s", text, "Replay Controls - Title", client,
+				GOKZ_FormatTime(GetPlaybackTime(bot), GOKZ_HUD_GetOption(client, HUDOption_TimerStyle) == TimerStyle_Precise));
+		}
+		else
+		{
+			Format(text, sizeof(text), "%s%T", text, "Replay Controls - Title", client);
+		}
 	}
 	else
 	{
-		FormatEx(text, sizeof(text), "%T", "Replay Controls - Title", client);
-		panel.SetTitle(text);
+		Format(text, sizeof(text), "%s%T", text, "Replay Controls - Title", client);
 	}
+
 
 	if(PlaybackGetTeleports(bot) > 0)
 	{
-		FormatEx(text, sizeof(text), "%T", "Replay Controls - Teleports", client, botTeleports[bot]);
-		panel.DrawItem(text, ITEMDRAW_RAWLINE);
+		Format(text, sizeof(text), "%s\n%T", text, "Replay Controls - Teleports", client, botTeleports[bot]);
 	}
+	menu.SetTitle(text);
 	
 	if (PlaybackPaused(bot))
 	{
 		FormatEx(text, sizeof(text), "%T", "Replay Controls - Resume", client);
-		panel.DrawItem(text);
+		menu.AddItem(ITEM_INFO_PAUSE, text);
 	}
 	else
 	{
 		FormatEx(text, sizeof(text), "%T", "Replay Controls - Pause", client);
-		panel.DrawItem(text);
+		menu.AddItem(ITEM_INFO_PAUSE, text);
 	}
 	
 	FormatEx(text, sizeof(text), "%T", "Replay Controls - Skip", client);
-	panel.DrawItem(text);
+	menu.AddItem(ITEM_INFO_SKIP, text);
 	
-	FormatEx(text, sizeof(text), "%T", "Replay Controls - Rewind", client);
-	panel.DrawItem(text);
-	
-	panel.DrawItem("", ITEMDRAW_SPACER);
+	FormatEx(text, sizeof(text), "%T\n ", "Replay Controls - Rewind", client);
+	menu.AddItem(ITEM_INFO_REWIND, text);
 	
 	FormatEx(text, sizeof(text), "%T", "Replay Controls - Freecam", client);
-	panel.DrawItem(text);
-
-	panel.DrawItem("", ITEMDRAW_SPACER);
-
-	FormatEx(text, sizeof(text), "%T", "Replay Controls - Exit", client);
-	panel.DrawItem(text);
+	menu.AddItem(ITEM_INFO_FREECAM, text);
 	
-	panel.Send(client, PanelHandler_ReplayControls, MENU_TIME_FOREVER);
-	delete panel;
+	menu.Display(client, MENU_TIME_FOREVER);
+
+	if (gB_GOKZHUD)
+	{
+		GOKZ_HUD_SetMenuShowing(client, true);
+	}
 }
 
 void ToggleReplayControls(int client)
@@ -133,7 +153,7 @@ bool IsReplayBotControlled(int bot, int botClient)
 				GetEntProp(controllingPlayer[bot], Prop_Send, "m_iObserverMode") == 6);
 }
 
-int PanelHandler_ReplayControls(Menu menu, MenuAction action, int param1, int param2)
+int MenuHandler_ReplayControls(Menu menu, MenuAction action, int param1, int param2)
 {
 	switch (action)
 	{
@@ -141,45 +161,48 @@ int PanelHandler_ReplayControls(Menu menu, MenuAction action, int param1, int pa
 		{
 			if (!IsValidClient(param1))
 			{
-				return 0;
+				return;
 			}
 
 			int bot = GetBotFromClient(GetObserverTarget(param1));
 			if (bot == -1 || controllingPlayer[bot] != param1)
 			{
-				return 0;
+				return;
 			}
 			
-			// Pause/Resume
-			if (param2 == 1)
+			char info[16];
+			menu.GetItem(param2, info, sizeof(info));
+			if (StrEqual(info, ITEM_INFO_PAUSE, false))
 			{
 				PlaybackTogglePause(bot);
-				ShowReplayControlMenu(param1, bot);
 			}
-			// Forward
-			else if (param2 == 2)
+			else if (StrEqual(info, ITEM_INFO_SKIP, false))
 			{
 				PlaybackSkipForward(bot);
 			}
-			// Rewind
-			else if (param2 == 3)
+			else if (StrEqual(info, ITEM_INFO_REWIND, false))
 			{
 				PlaybackSkipBack(bot);
 			}
-			// Freecam
-			else if (param2 == 4)
+			else if (StrEqual(info, ITEM_INFO_FREECAM, false))
 			{
 				SetEntProp(param1, Prop_Send, "m_iObserverMode", 6);
 			}
-			// Exit
-			else if (param2 == 7)
+			GOKZ_HUD_SetMenuShowing(param1, false);
+		}
+		case MenuAction_Cancel:
+		{
+			GOKZ_HUD_SetMenuShowing(param1, false);
+			if (param2 == MenuCancel_Exit)
 			{
 				CancelReplayControls(param1);
-				delete menu;
 			}
 		}
+		case MenuAction_End:
+		{
+			delete menu;
+		}
 	}
-	return 0;
 }
 
 void CancelReplayControls(int client)

--- a/addons/sourcemod/scripting/include/gokz/hud.inc
+++ b/addons/sourcemod/scripting/include/gokz/hud.inc
@@ -25,6 +25,8 @@ enum HUDOption:
 	HUDOption_SpeedText, 
 	HUDOption_ShowWeapon,
 	HUDOption_ShowControls, 
+	HUDOption_SpectatorList,
+	HUDOption_SpectatorListPosition,
 	HUDOPTION_COUNT
 };
 
@@ -97,7 +99,20 @@ enum
 	REPLAYCONTROLS_COUNT
 };
 
+enum
+{
+	SpectatorList_Disabled = 0,
+	SpectatorList_Simple,
+	SpectatorList_Advanced,
+	SPECTATORLIST_COUNT
+};
 
+enum
+{
+	SpectatorListPosition_TPMenu = 0,
+	SpectatorListPosition_InfoPanel,
+	SPECTATORLISTPOSITION_COUNT
+}
 
 // =====[ STRUCTS ]======
 
@@ -140,7 +155,9 @@ stock char gC_HUDOptionNames[HUDOPTION_COUNT][] =
 	"GOKZ HUD - Show Time Type",
 	"GOKZ HUD - Speed Text", 
 	"GOKZ HUD - Show Weapon",
-	"GOKZ HUD - Show Controls"
+	"GOKZ HUD - Show Controls",
+	"GOKZ HUD - Spectator List",
+	"GOKZ HUD - Spec List Pos",
 };
 
 stock char gC_HUDOptionDescriptions[HUDOPTION_COUNT][] = 
@@ -153,7 +170,9 @@ stock char gC_HUDOptionDescriptions[HUDOPTION_COUNT][] =
 	"Timer Type - 0 = Disabled, 1 = Enabled", 
 	"Speed Display - 0 = Disabled, 1 = Centre Panel, 2 = Bottom", 
 	"Weapon Viewmodel - 0 = Disabled, 1 = Enabled",
-	"Replay Controls Display - 0 = Disbled, 1 = Enabled"
+	"Replay Controls Display - 0 = Disbled, 1 = Enabled",
+	"Spectator List - 0 = Disabled, 1 = Player count, 2 = Player count and names",
+	"Spectator List Position - 0 = Teleport Menu, 2 = Center Panel"
 };
 
 stock char gC_HUDOptionPhrases[HUDOPTION_COUNT][] = 
@@ -166,7 +185,9 @@ stock char gC_HUDOptionPhrases[HUDOPTION_COUNT][] =
 	"Options Menu - Timer Type",
 	"Options Menu - Speed Text", 
 	"Options Menu - Show Weapon",
-	"Options Menu - Show Controls"
+	"Options Menu - Show Controls",
+	"Options Menu - Spectator List",
+	"Options Menu - Spectator List Position"
 };
 
 stock int gI_HUDOptionCounts[HUDOPTION_COUNT] = 
@@ -179,7 +200,9 @@ stock int gI_HUDOptionCounts[HUDOPTION_COUNT] =
 	TIMERTYPE_COUNT, 
 	SPEEDTEXT_COUNT, 
 	SHOWWEAPON_COUNT,
-	REPLAYCONTROLS_COUNT
+	REPLAYCONTROLS_COUNT,
+	SPECTATORLIST_COUNT,
+	SPECTATORLISTPOSITION_COUNT
 };
 
 stock int gI_HUDOptionDefaults[HUDOPTION_COUNT] = 
@@ -237,7 +260,44 @@ stock char gC_ShowControlsPhrases[REPLAYCONTROLS_COUNT][] =
 	"Options Menu - Enabled"
 };
 
+stock char gC_SpectatorListPhrases[SPECTATORLIST_COUNT][] =
+{
+	"Options Menu - Disabled",
+	"Options Menu - Player Count",
+	"Options Menu - Player Count & Names"
+};
 
+stock char gC_SpectatorListPositionPhrases[SPECTATORLISTPOSITION_COUNT][] =
+{
+	"Options Menu - Teleport Menu",
+	"Options Menu - Info Panel"
+}
+
+// =====[ NATIVES ]=====
+
+/**
+ * Returns whether the GOKZ HUD menu is showing for a client.
+ *
+ * @param client		Client index.
+ * @return				Whether the GOKZ HUD menu is showing.
+ */
+native bool GOKZ_HUD_GetMenuShowing(int client);
+
+/**
+ * Sets whether the GOKZ HUD menu would be showing for a client.
+ *
+ * @param client		Client index.
+ * @param value			Whether the GOKZ HUD menu would be showing for a client.
+ */
+native void GOKZ_HUD_SetMenuShowing(int client, bool value);
+
+/**
+ * Gets the spectator text for the menu. Used by GOKZ-replays.
+ *
+ * @param client		Client index.
+ * @param value			Whether the GOKZ HUD menu would be showing for a client.
+ */
+native void GOKZ_HUD_GetMenuSpectatorText(int client, any[] info, char[] buffer, int size);
 
 // =====[ STOCKS ]=====
 
@@ -327,3 +387,12 @@ public SharedPlugin __pl_gokz_hud =
 	required = 0, 
 	#endif
 };
+
+#if !defined REQUIRE_PLUGIN
+public void __pl_gokz_hud_SetNTVOptional()
+{
+	MarkNativeAsOptional("GOKZ_HUD_GetMenuShowing");
+	MarkNativeAsOptional("GOKZ_HUD_SetMenuShowing");
+	MarkNativeAsOptional("GOKZ_HUD_GetMenuSpectatorText");
+}
+#endif

--- a/addons/sourcemod/scripting/include/gokz/kzplayer.inc
+++ b/addons/sourcemod/scripting/include/gokz/kzplayer.inc
@@ -421,6 +421,32 @@ methodmap KZPlayer < MovementAPIPlayer {
 		}
 	}
 	
+	property int SpectatorList {
+		public get() {
+			return this.GetHUDOption(HUDOption_SpectatorList);
+		}
+		public set(int value){
+			this.SetHUDOption(HUDOption_SpectatorList, value);
+		}
+	}
+
+	property int SpectatorListPosition {
+		public get() {
+			return this.GetHUDOption(HUDOption_SpectatorListPosition);
+		}
+		public set(int value){
+			this.SetHUDOption(HUDOption_SpectatorListPosition, value);
+		}
+	}
+
+	property bool MenuShowing {
+		public get() {
+			return GOKZ_HUD_GetMenuShowing(this.ID);
+		}
+		public set(bool value) {
+			GOKZ_HUD_SetMenuShowing(this.ID, value);
+		}
+	}
 	#endif
 	// =====[ END HUD ]=====
 	

--- a/addons/sourcemod/scripting/include/gokz/replays.inc
+++ b/addons/sourcemod/scripting/include/gokz/replays.inc
@@ -223,6 +223,12 @@ native int GOKZ_RP_GetPlaybackInfo(int client, any[] info);
  */
 native int GOKZ_RP_LoadJumpReplay(int client, char[] path);
 
+/**
+ * Called by the HUD to show the replay control menu.
+ *
+ * @param client			Client index.
+ */
+native bool GOKZ_RP_UpdateReplayControlMenu(int client);
 
 
 // =====[ DEPENDENCY ]=====
@@ -243,5 +249,6 @@ public void __pl_gokz_replays_SetNTVOptional()
 {
 	MarkNativeAsOptional("GOKZ_RP_GetPlaybackInfo");
 	MarkNativeAsOptional("GOKZ_RP_LoadJumpReplay");
+	MarkNativeAsOptional("GOKZ_RP_UpdateReplayControlMenu");
 }
 #endif

--- a/addons/sourcemod/translations/gokz-hud.phrases.txt
+++ b/addons/sourcemod/translations/gokz-hud.phrases.txt
@@ -230,6 +230,14 @@
 	{
 		"en"		"Show replay controls"
 	}
+	"Options Menu - Spectator List"
+	{
+		"en"		"Spectator list"
+	}
+	"Options Menu - Spectator List Position"
+	{
+		"en"		"Spectator list position"
+	}
 
 
 	// =====[ RACING ]=====
@@ -242,5 +250,37 @@
 	{
 		"en"		"GO!"
 		"ru"		"НАЧАЛИ!"
+	}
+
+	// =====[ SPECTATOR LIST ]=====
+	"Spectator List - Menu (Simple)"
+	{
+		"#format"	"{1:d}"
+		"en"		"Specs: {1}"
+	}
+	"Spectator List - Menu (Advanced)"
+	{
+		"#format"	"{1:d},{2:s}"
+		"en"		"Specs ({1})\n{2}"
+	}
+	"Spectator List - Info Panel (Simple)"
+	{
+		// Specs: 2
+		"#format"	"{1:d}"
+		"en"		"Specs: <font color='#ffffff'>{1}</font>"
+	}
+	"Spectator List - Info Panel (Advanced)"
+	{
+		// Specs (2): P1, P2
+		"#format"	"{1:d},{2:s}"
+		"en"		"Specs ({1}): <font color='#ffffff'>{2}</font>"
+	}
+	"Options Menu - Player Count"
+	{
+		"en"		"Player count"
+	}
+	"Options Menu - Player Count & Names"
+	{
+		"en"		"Player count & names"
 	}
 }

--- a/cfg/sourcemod/gokz/options_menu_sorting.cfg
+++ b/cfg/sourcemod/gokz/options_menu_sorting.cfg
@@ -32,6 +32,8 @@
 		"item"		"GOKZ HUD - Show Weapon"
 		"item"		"GOKZ HUD - Show Controls"
 		"item"		"GOKZ HUD - Show Time Type"
+		"item"		"GOKZ HUD - Spectator List"
+		"item"		"GOKZ HUD - Spectator List Position"
 	}
 	"Jumpstats"
 	{


### PR DESCRIPTION
Edit: STILL A WIP
Timer text logic is rewritten for the menu, and is now located at `tp_menu.sp` instead.

The replay control menu now uses `Menu` instead of a `Panel` for a proper exit button. Some HUD and Replays natives are added for this as well.