### PR TITLE
Show warning on CP in CP disabled area

### DIFF
--- a/addons/sourcemod/scripting/gokz-core/teleports.sp
+++ b/addons/sourcemod/scripting/gokz-core/teleports.sp
@@ -115,7 +115,12 @@ void MakeCheckpoint(int client)
 	{
 		GOKZ_PrintToChat(client, true, "%t", "Make Checkpoint", checkpointCount[client]);
 	}
-	
+
+	if (!GetTimerRunning(client) && AntiCpTriggerIsTouched(client))
+	{
+		GOKZ_PrintToChat(client, true, "%t", "Anti Checkpoint Area Warning");
+	}
+
 	// Call Post Forward
 	Call_GOKZ_OnMakeCheckpoint_Post(client);
 }

--- a/addons/sourcemod/translations/gokz-core.phrases.txt
+++ b/addons/sourcemod/translations/gokz-core.phrases.txt
@@ -53,6 +53,10 @@
 		"chi"		"{grey}你存储了一个存点 (#{default}{1}{grey})."
 		"ru"		"{grey}Вы поставили чекпойнт (#{default}{1}{grey})."
 	}
+	"Anti Checkpoint Area Warning"
+	{
+		"en"		"{yellow}Warning{grey}: Checkpoint created in checkpoint disabled area."
+	}
 	"Can't Checkpoint (Midair)"
 	{
 		"en"		"{darkred}You can't make a checkpoint mid-air."


### PR DESCRIPTION
Adds a message that will show in case a player has the timer off and
creates a CP in an area that is marked to have CPs disabled. If the
timer is running, the player will not be able to create a CP.

It adds the message so that the user can test in what places its
possible to create CPs without having the timer on. This reduces
confusion and makes the routing process easier.

(Message edited after this, too lazy to take new screenshot...)
![image](https://user-images.githubusercontent.com/5192434/162793653-4206b171-4c99-49d3-b221-452cea0cdc90.png)

Implements #313 