### PR TITLE
Check if map is running also when Demofix is disabled

### DIFF
--- a/addons/sourcemod/scripting/gokz-core/demofix.sp
+++ b/addons/sourcemod/scripting/gokz-core/demofix.sp
@@ -72,6 +72,11 @@ static void DoDemoFix()
 	{
 		case 0:
 		{
+			if (!mapRunning)
+			{
+				return;
+			}
+
 			GameRules_SetProp("m_bWarmupPeriod", 0);
 		}
 		case 1:


### PR DESCRIPTION
The check is done before accessing the gamerules in the EnableDemoRecord
function when the demofix is enabled. When you have set Demofix to be
disabled it will attempt to access the Gamerules too early during map
load, causing an "Couldn't find gamerules proxy entity" exception.

This commit fixes that issue by making sure that we are only running the
SetProp when the map is actually running.

Fixes: #309 