### PR TITLE
Add warning message when starting a non-global run

### DIFF
--- a/addons/sourcemod/scripting/gokz-global.sp
+++ b/addons/sourcemod/scripting/gokz-global.sp
@@ -259,6 +259,21 @@ public void GlobalAPI_OnInitialized()
 	SetupAPI();
 }
 
+
+public Action GOKZ_OnTimerStart(int client, int course)
+{
+	KZPlayer player = KZPlayer(client);
+	int mode = player.Mode;
+
+	// We check the timer running to prevent spam when standing inside VB.
+	if (GlobalAPI_HasAPIKey() && !GlobalsEnabled(mode) && !GOKZ_GetTimerRunning(client))
+	{
+		GOKZ_PrintToChat(client, true, "%t", "Warn Player Not Global Run");
+	}
+
+	return Plugin_Continue;
+}
+
 public void GOKZ_OnTimerStart_Post(int client, int course)
 {
 	KZPlayer player = KZPlayer(client);

--- a/addons/sourcemod/scripting/gokz-global.sp
+++ b/addons/sourcemod/scripting/gokz-global.sp
@@ -54,6 +54,7 @@ int gI_MapFileSize;
 int gI_MapTier;
 
 ConVar gCV_gokz_settings_enforcer;
+ConVar gCV_gokz_warn_for_non_global_map;
 ConVar gCV_EnforcedCVar[ENFORCEDCVAR_COUNT];
 
 #include "gokz-global/api.sp"
@@ -266,7 +267,10 @@ public Action GOKZ_OnTimerStart(int client, int course)
 	int mode = player.Mode;
 
 	// We check the timer running to prevent spam when standing inside VB.
-	if (GlobalAPI_HasAPIKey() && !GlobalsEnabled(mode) && !GOKZ_GetTimerRunning(client))
+	if (gCV_gokz_warn_for_non_global_map.BoolValue
+		&& GlobalAPI_HasAPIKey()
+		&& !GlobalsEnabled(mode)
+		&& !GOKZ_GetTimerRunning(client))
 	{
 		GOKZ_PrintToChat(client, true, "%t", "Warn Player Not Global Run");
 	}
@@ -527,6 +531,7 @@ static void CreateConVars()
 	AutoExecConfig_SetCreateFile(true);
 	
 	gCV_gokz_settings_enforcer = AutoExecConfig_CreateConVar("gokz_settings_enforcer", "1", "Whether GOKZ enforces convars required for global records.", _, true, 0.0, true, 1.0);
+	gCV_gokz_warn_for_non_global_map = AutoExecConfig_CreateConVar("gokz_warn_for_non_global_map", "1", "Whether or not GOKZ should warn players if the global check does not pass.", _, true, 0.0, true, 1.0);
 	gCV_gokz_settings_enforcer.AddChangeHook(OnConVarChanged);
 	
 	AutoExecConfig_ExecuteFile();

--- a/addons/sourcemod/translations/gokz-global.phrases.txt
+++ b/addons/sourcemod/translations/gokz-global.phrases.txt
@@ -200,6 +200,10 @@
 		"en"		"Your m_yaw value must be less or equal to 0.3 to play on this server"
 		"ru"		"Ваше значение m_yaw должно быть меньше или равно 0.3 для игры на этом сервере."
 	}
+	"Warn Player Not Global Run"
+	{
+		"en"		"{yellow}Warning{grey}: The current map did not pass the Global check. Global times will not save. See {default}!globalcheck{grey} for more information."
+	}
 
 
 	// =====[ GLOBAL TOP MENU ]=====


### PR DESCRIPTION
In case the map is the wrong version, or the server is not updated the
user might not realize that the run will not be saved in the global api.
To avoid the confusion, we show them an error message.

To prevent spam of the message, we first check if the server is intended
to be global, by verifying that the GlobalApi plugin has a key set.
Further if the user already has a run going when resetting the timer,
they will not get the message again. If they stop the timer and start it
again, it will show the message again.

Implements: #316 