### PR TITLE
Fix bot being stuck at 0,0,0 caused by invalid ArrayList block size

### DIFF
--- a/addons/sourcemod/scripting/gokz-replays/playback.sp
+++ b/addons/sourcemod/scripting/gokz-replays/playback.sp
@@ -409,7 +409,7 @@ static void LoadFormatVersion1Replay(File file, int bot)
 	// Setup playback tick data array list
 	if (playbackTickData[bot] == null)
 	{
-		playbackTickData[bot] = new ArrayList(RP_V1_TICK_DATA_BLOCKSIZE, length);
+		playbackTickData[bot] = new ArrayList(IntMax(RP_V1_TICK_DATA_BLOCKSIZE, sizeof(ReplayTickData)), length);
 	}
 	else
 	{  // Make sure it's all clear and the correct size
@@ -603,10 +603,10 @@ static bool LoadFormatVersion2Replay(File file, int client, int bot)
 	// Setup playback tick data array list
 	if (playbackTickData[bot] == null)
 	{
-		playbackTickData[bot] = new ArrayList(sizeof(ReplayTickData));
+		playbackTickData[bot] = new ArrayList(IntMax(RP_V1_TICK_DATA_BLOCKSIZE, sizeof(ReplayTickData));
 	}
 	else
-	{  // Make sure it's all clear and the correct size
+	{
 		playbackTickData[bot].Clear();
 	}
 	

--- a/addons/sourcemod/scripting/gokz-replays/playback.sp
+++ b/addons/sourcemod/scripting/gokz-replays/playback.sp
@@ -603,7 +603,7 @@ static bool LoadFormatVersion2Replay(File file, int client, int bot)
 	// Setup playback tick data array list
 	if (playbackTickData[bot] == null)
 	{
-		playbackTickData[bot] = new ArrayList(IntMax(RP_V1_TICK_DATA_BLOCKSIZE, sizeof(ReplayTickData));
+		playbackTickData[bot] = new ArrayList(IntMax(RP_V1_TICK_DATA_BLOCKSIZE, sizeof(ReplayTickData)));
 	}
 	else
 	{


### PR DESCRIPTION
If the first replay loaded by the bot is a version 1 replay, the block size will not be enough for version 2 replay.