### PR TITLE
Update the first tick takeoff info in case of jumpbug

### DIFF
--- a/addons/sourcemod/scripting/gokz-jumpstats/jump_tracking.sp
+++ b/addons/sourcemod/scripting/gokz-jumpstats/jump_tracking.sp
@@ -116,6 +116,8 @@ enum struct JumpTracker
 		
 		// Reset pose history
 		this.poseIndex = 0;
+		// Update the first tick if it is a jumpbug.
+		this.UpdateOnGround();
 	}
 	
 	void Begin()


### PR DESCRIPTION
Fixes the bug where the angles of the first strafe of jumpbugs is not correct.

