### PR TITLE
Revert space to tab changes in jump reports

### DIFF
--- a/addons/sourcemod/scripting/gokz-jumpstats/jump_reporting.sp
+++ b/addons/sourcemod/scripting/gokz-jumpstats/jump_reporting.sp
@@ -240,12 +240,12 @@ static void DoConsoleReport(int client, bool isFailstat, Jump jump, int tier, ch
 	PrintToConsole(client, "  #.  %12t%12t%12t%12t%12t%9t%t", "Sync (Table)", "Gain (Table)", "Loss (Table)", "Airtime (Table)", "Width (Table)", "Overlap (Table)", "Dead Air (Table)");
 	if (jump.strafes_ticks[0] > 0)
 	{
-		PrintToConsole(client, "  0.  ----	  -----	 -----	 %3.0f%%	  -----	 --	 --", GetStrafeAirtime(jump, 0));
+		PrintToConsole(client, "  0.  ----      -----     -----     %3.0f%%      -----     --     --", GetStrafeAirtime(jump, 0));
 	}
 	for (int strafe = 1; strafe <= jump.strafes && strafe < JS_MAX_TRACKED_STRAFES; strafe++)
 	{
-		PrintToConsole(client, 
-			" %2d.  %3.0f%%	  %5.2f	 %5.2f	 %3.0f%%	  %5.1f°	%2d	 %2d", 
+		PrintToConsole(client,
+			" %2d.  %3.0f%%      %5.2f     %5.2f     %3.0f%%      %5.1f°    %2d     %2d", 
 			strafe, 
 			GetStrafeSync(jump, strafe),
 			jump.strafes_gain[strafe],


### PR DESCRIPTION
This commit caused the jump report to no longer line up properly:  https://github.com/KZGlobalTeam/gokz/commit/812c99af6a17b303a3687f2e6b002c855958df56 
