### PR TITLE
Track ground entity for saveloc

### DIFF
--- a/addons/sourcemod/scripting/gokz-saveloc.sp
+++ b/addons/sourcemod/scripting/gokz-saveloc.sp
@@ -41,6 +41,7 @@ enum struct Location {
 	ArrayList undoTeleportData;
 
 	// Movement related states
+	int groundEnt;
 	int flags;
 	float position[3];
 	float angles[3];
@@ -61,6 +62,7 @@ enum struct Location {
 	void Create(int client, int target)
 	{
 		GetClientName(client, this.locationCreator, sizeof(Location::locationCreator));
+		this.groundEnt = GetEntPropEnt(target, Prop_Data, "m_hGroundEntity");
 		this.flags = GetEntityFlags(target);
 		this.mode = GOKZ_GetCoreOption(target, Option_Mode);
 		this.course = GOKZ_GetCourse(target);
@@ -110,6 +112,7 @@ enum struct Location {
 		GOKZ_SetTeleportCount(client, this.teleportCount);
 		GOKZ_SetUndoTeleportData(client, this.undoTeleportData, GOKZ_CHECKPOINT_VERSION);
 
+		SetEntPropEnt(client, Prop_Data, "m_hGroundEntity", this.groundEnt);
 		SetEntityFlags(client, this.flags);
 		TeleportEntity(client, this.position, this.angles, this.velocity);
 		SetEntPropFloat(client, Prop_Send, "m_flDuckAmount", this.duckAmount);


### PR DESCRIPTION
Speculative fix for an issue where `FL_ONGROUND` flag is not correctly applied even though the player is on the ground, if the player manages to make a saveloc on the exact landing tick, breaking prestrafing and hud elements.