### PR TITLE
Use actual bots instead of fake client for interpolation, fix bots having no sound, increase bots limit, reworked name update logic

### DIFF
--- a/addons/sourcemod/scripting/gokz-replays.sp
+++ b/addons/sourcemod/scripting/gokz-replays.sp
@@ -124,6 +124,8 @@ public void OnConfigsExecuted()
 	FindConVar("bot_zombie").BoolValue = true;
 	FindConVar("bot_join_after_player").BoolValue = false;
 	FindConVar("bot_quota_mode").SetString("normal");
+	FindConVar("bot_quota").Flags &= ~FCVAR_NOTIFY;
+	FindConVar("bot_quota").Flags &= ~FCVAR_REPLICATED;
 }
 
 public void OnEntityCreated(int entity, const char[] classname)

--- a/addons/sourcemod/scripting/gokz-replays/playback.sp
+++ b/addons/sourcemod/scripting/gokz-replays/playback.sp
@@ -15,6 +15,10 @@ static ArrayList playbackTickData[RP_MAX_BOTS];
 static bool inBreather[RP_MAX_BOTS];
 static float breatherStartTime[RP_MAX_BOTS];
 
+// Original bot caller, needed for OnClientPutInServer callback
+static int botCaller[RP_MAX_BOTS];
+// Original bot name after creation by bot_add, needed for bot removal
+static char botName[RP_MAX_BOTS][MAX_NAME_LENGTH];
 static bool botInGame[RP_MAX_BOTS];
 static int botClient[RP_MAX_BOTS];
 static bool botDataLoaded[RP_MAX_BOTS];
@@ -81,9 +85,7 @@ int LoadReplayBot(int client, char[] path)
 		GOKZ_PlayErrorSound(client);
 		return -1;
 	}
-
-	SetBotStuff(bot);
-	MakePlayerSpectate(client, botClient[bot]);
+	botCaller[bot] = client;
 	return botClient[bot];
 }
 
@@ -250,10 +252,18 @@ void OnClientPutInServer_Playback(int client)
 	// Check if an unassigned bot has joined, and assign it
 	for (int bot; bot < RP_MAX_BOTS; bot++)
 	{
-		if (!botInGame[bot])
+		// Also check if the bot was created by us.
+		if (!botInGame[bot] && botCaller[bot] != 0)
 		{
 			botInGame[bot] = true;
 			botClient[bot] = client;
+			GetClientName(client, botName[bot], sizeof(botName[]));
+			SetBotStuff(bot);
+			if (IsValidClient(botCaller[bot]))
+			{
+				MakePlayerSpectate(botCaller[bot], botClient[bot]);
+				botCaller[bot] = 0;
+			}
 			break;
 		}
 	}
@@ -714,7 +724,7 @@ static void PlaybackVersion1(int client, int bot, int &buttons)
 				playbackTickData[bot].Clear(); // Clear it all out
 				botDataLoaded[bot] = false;
 				CancelReplayControlsForBot(bot);
-				KickClient(botClient[bot]);
+				ServerCommand("bot_kick %s", botName[bot]);
 			}
 		}
 	}
@@ -734,7 +744,7 @@ static void PlaybackVersion1(int client, int bot, int &buttons)
 			playbackTickData[bot].Clear();
 			botDataLoaded[bot] = false;
 			CancelReplayControlsForBot(bot);
-			KickClient(botClient[bot]);
+			ServerCommand("bot_kick %s", botName[bot]);
 			return;
 		}
 		
@@ -879,7 +889,7 @@ void PlaybackVersion2(int client, int bot, int &buttons)
 				playbackTickData[bot].Clear(); // Clear it all out
 				botDataLoaded[bot] = false;
 				CancelReplayControlsForBot(bot);
-				KickClient(botClient[bot]);
+				ServerCommand("bot_kick %s", botName[bot]);
 			}
 		}
 	}
@@ -899,7 +909,7 @@ void PlaybackVersion2(int client, int bot, int &buttons)
 			playbackTickData[bot].Clear();
 			botDataLoaded[bot] = false;
 			CancelReplayControlsForBot(bot);
-			KickClient(botClient[bot]);
+			ServerCommand("bot_kick %s", botName[bot]);
 			return;
 		}
 		
@@ -1096,7 +1106,7 @@ static void SetBotStuff(int bot)
 	{
 		return;
 	}
-	
+
 	int client = botClient[bot];
 	
 	// Set its movement options just in case it could negatively affect the playback
@@ -1106,17 +1116,6 @@ static void SetBotStuff(int bot)
 	// Clan tag and name
 	SetBotClanTag(bot);
 	SetBotName(bot);
-
-	// Set the bot's team based on if it's NUB or PRO
-	if (botReplayType[bot] == ReplayType_Run 
-		&& GOKZ_GetTimeTypeEx(botTeleportsUsed[bot]) == TimeType_Pro)
-	{
-		GOKZ_JoinTeam(client, CS_TEAM_CT);
-	}
-	else
-	{
-		GOKZ_JoinTeam(client, CS_TEAM_T);
-	}
 
 	// Set bot weapons
 	// Always start by removing the pistol and knife
@@ -1253,7 +1252,16 @@ static int GetUnusedBot()
 	{
 		if (!botInGame[bot])
 		{
-			CreateFakeClient("botName");
+			// Set the bot's team based on if it's NUB or PRO
+			if (botReplayType[bot] == ReplayType_Run 
+				&& GOKZ_GetTimeTypeEx(botTeleportsUsed[bot]) == TimeType_Pro)
+			{
+				ServerCommand("bot_add_ct");
+			}
+			else
+			{
+				ServerCommand("bot_add_t");
+			}
 			return bot;
 		}
 	}
@@ -1344,33 +1352,13 @@ static void MakePlayerSpectate(int client, int bot)
 	DataPack data = new DataPack();
 	data.WriteCell(clientUserID);
 	data.WriteCell(GetClientUserId(bot));
-
-	CreateTimer(0.2, Timer_ResetSpectate, clientUserID);
-	CreateTimer(0.3, Timer_SpectateBot, data); // After delay so name is correctly updated in client's HUD
+	CreateTimer(0.1, Timer_UpdateBotName, GetClientUserId(bot));
 	EnableReplayControls(client);
 }
 
-public Action Timer_ResetSpectate(Handle timer, int clientUID)
+public Action Timer_UpdateBotName(Handle timer, int botUID)
 {
-	int client = GetClientOfUserId(clientUID);
-	if (IsValidClient(client))
-	{
-		SetEntProp(client, Prop_Send, "m_iObserverMode", -1);
-		SetEntPropEnt(client, Prop_Send, "m_hObserverTarget", -1);
-	}
-}
-public Action Timer_SpectateBot(Handle timer, DataPack data)
-{
-	data.Reset();
-	int client = GetClientOfUserId(data.ReadCell());
-	int bot = GetClientOfUserId(data.ReadCell());
-	delete data;
-	
-	if (IsValidClient(client) && IsValidClient(bot))
-	{
-		GOKZ_JoinTeam(client, CS_TEAM_SPECTATOR);
-		SetEntProp(client, Prop_Send, "m_iObserverMode", 4);
-		SetEntPropEnt(client, Prop_Send, "m_hObserverTarget", bot);
-	}
-	return Plugin_Continue;
+	Event e = CreateEvent("spec_target_updated");
+	e.SetInt("userid", botUID);
+	e.Fire();
 }

--- a/addons/sourcemod/scripting/gokz-replays/playback.sp
+++ b/addons/sourcemod/scripting/gokz-replays/playback.sp
@@ -778,6 +778,7 @@ static void PlaybackVersion1(int client, int bot, int &buttons)
 		CopyVector(repOrigin, botLastOrigin[bot]);
 		
 		botSpeed[bot] = GetVectorHorizontalLength(velocity);
+		buttons = repButtons;
 		botButtons[bot] = repButtons;
 
 		// Should the bot be ducking?!
@@ -945,54 +946,56 @@ void PlaybackVersion2(int client, int bot, int &buttons)
 		botSpeed[bot] = GetVectorHorizontalLength(currentTickData.velocity);
 
 		// Set buttons
+		int newButtons;
 		if (currentTickData.flags & RP_IN_ATTACK)
 		{
-			buttons |= IN_ATTACK;
+			newButtons |= IN_ATTACK;
 		}
 		if (currentTickData.flags & RP_IN_ATTACK2)
 		{
-			buttons |= IN_ATTACK2;
+			newButtons |= IN_ATTACK2;
 		}
 		if (currentTickData.flags & RP_IN_JUMP)
 		{
-			buttons |= IN_JUMP;
+			newButtons |= IN_JUMP;
 		}
 		if (currentTickData.flags & RP_IN_DUCK || currentTickData.flags & RP_FL_DUCKING)
 		{
-			buttons |= IN_DUCK;
+			newButtons |= IN_DUCK;
 		}
 		if (currentTickData.flags & RP_IN_FORWARD)
 		{
-			buttons |= IN_FORWARD;
+			newButtons |= IN_FORWARD;
 		}
 		if (currentTickData.flags & RP_IN_BACK)
 		{
-			buttons |= IN_BACK;
+			newButtons |= IN_BACK;
 		}
 		if (currentTickData.flags & RP_IN_LEFT)
 		{
-			buttons |= IN_LEFT;
+			newButtons |= IN_LEFT;
 		}
 		if (currentTickData.flags & RP_IN_RIGHT)
 		{
-			buttons |= IN_RIGHT;
+			newButtons |= IN_RIGHT;
 		}
 		if (currentTickData.flags & RP_IN_MOVELEFT)
 		{
-			buttons |= IN_MOVELEFT;
+			newButtons |= IN_MOVELEFT;
 		}
 		if (currentTickData.flags & RP_IN_MOVERIGHT)
 		{
-			buttons |= IN_MOVERIGHT;
+			newButtons |= IN_MOVERIGHT;
 		}
 		if (currentTickData.flags & RP_IN_RELOAD)
 		{
-			buttons |= IN_RELOAD;
+			newButtons |= IN_RELOAD;
 		}
 		if (currentTickData.flags & RP_IN_SPEED)
 		{
-			buttons |= IN_SPEED;
+			newButtons |= IN_SPEED;
 		}
+		buttons = newButtons;
 		botButtons[bot] = buttons;
 
 		int entityFlags = GetEntityFlags(client);

--- a/addons/sourcemod/scripting/gokz-replays/recording.sp
+++ b/addons/sourcemod/scripting/gokz-replays/recording.sp
@@ -224,12 +224,6 @@ public Action Timer_EndRecording(Handle timer, DataPack data)
 
 	runningRunBreatherTimer[client] = INVALID_HANDLE;
 	postRunRecording[client] = false;
-
-	if (gB_GOKZLocalDB && GOKZ_DB_IsCheater(client))
-	{
-		Call_OnTimerEnd_Post(client, "", course, time, teleportsUsed);
-		return Plugin_Stop;
-	}
 	
 	char path[PLATFORM_MAX_PATH];
 	if (SaveRecordingOfRun(path, client, course, time, teleportsUsed))

--- a/addons/sourcemod/scripting/gokz-replays/recording.sp
+++ b/addons/sourcemod/scripting/gokz-replays/recording.sp
@@ -224,6 +224,12 @@ public Action Timer_EndRecording(Handle timer, DataPack data)
 
 	runningRunBreatherTimer[client] = INVALID_HANDLE;
 	postRunRecording[client] = false;
+
+	if (gB_GOKZLocalDB && GOKZ_DB_IsCheater(client))
+	{
+		Call_OnTimerEnd_Post(client, "", course, time, teleportsUsed);
+		return Plugin_Stop;
+	}
 	
 	char path[PLATFORM_MAX_PATH];
 	if (SaveRecordingOfRun(path, client, course, time, teleportsUsed))

--- a/addons/sourcemod/scripting/include/gokz/replays.inc
+++ b/addons/sourcemod/scripting/include/gokz/replays.inc
@@ -130,7 +130,7 @@ enum struct ReplayTickData
 #define RP_NAV_FILE "maps/gokz-replays.nav"
 #define RP_V1_TICK_DATA_BLOCKSIZE 7
 #define RP_CACHE_BLOCKSIZE 4
-#define RP_MAX_BOTS 2
+#define RP_MAX_BOTS 4
 #define RP_PLAYBACK_BREATHER_TIME 2.0
 #define RP_MIN_CHEATER_REPLAY_LENGTH 30 // 30 seconds
 #define RP_MAX_CHEATER_REPLAY_LENGTH 120 // 2 minutes

--- a/cfg/sourcemod/gokz/gokz.cfg
+++ b/cfg/sourcemod/gokz/gokz.cfg
@@ -57,6 +57,8 @@ mp_footsteps_serverside 1
 sv_mincmdrate 128
 sv_minupdaterate 128
 mp_warmuptime_all_players_connected 0
+// Fix bots not spawning
+mp_randomspawn 1
 
 // Team picking
 mp_force_pick_time 60


### PR DESCRIPTION
Resolves #335.

A fake client is not a bot. The client doesn't store data for interpolation if the bot isn't initialized properly. Using `bot_add` should preserve the "no bot in server" behavior. Modifying `bot_quota` cvar is also an option, but that might mess with other plugins that happen to use bots as well.

Bot name updating now no longer requires the player to be put out of spectator mode, `spec_target_updated` event is fired instead.