### PR TITLE
Always upload replays on personal best

### DIFF
--- a/addons/sourcemod/scripting/gokz-global.sp
+++ b/addons/sourcemod/scripting/gokz-global.sp
@@ -293,12 +293,14 @@ public void GOKZ_OnTimerEnd_Post(int client, int course, float time, int telepor
 	}
 }
 
-public void GOKZ_RP_OnReplaySaved(int client, int replayType, const char[] map, int course, int timeType, float time, const char[] filePath)
+public Action GOKZ_RP_OnReplaySaved(int client, int replayType, const char[] map, int course, int timeType, float time, const char[] filePath, bool tempReplay)
 {
 	if (gB_GloballyVerified[client] && gB_InValidRun[client])
 	{
-		OnReplaySaved_SendReplay(client, replayType, map, course, timeType, time, filePath);
+		OnReplaySaved_SendReplay(client, replayType, map, course, timeType, time, filePath, tempReplay);
+		return Plugin_Handled;
 	}
+	return Plugin_Continue;
 }
 
 public void GOKZ_OnRunInvalidated(int client)

--- a/addons/sourcemod/scripting/gokz-replays/api.sp
+++ b/addons/sourcemod/scripting/gokz-replays/api.sp
@@ -32,13 +32,14 @@ public int Native_RP_LoadJumpReplay(Handle plugin, int numParams)
 
 void CreateGlobalForwards()
 {
-	H_OnReplaySaved = new GlobalForward("GOKZ_RP_OnReplaySaved", ET_Ignore, Param_Cell, Param_Cell, Param_String, Param_Cell, Param_Cell, Param_Float, Param_String);
+	H_OnReplaySaved = new GlobalForward("GOKZ_RP_OnReplaySaved", ET_Event, Param_Cell, Param_Cell, Param_String, Param_Cell, Param_Cell, Param_Float, Param_String, Param_Cell);
 	H_OnReplayDiscarded = new GlobalForward("GOKZ_RP_OnReplayDiscarded", ET_Ignore, Param_Cell);
 	H_OnTimerEnd_Post = new GlobalForward("GOKZ_RP_OnTimerEnd_Post", ET_Ignore, Param_Cell, Param_String, Param_Cell, Param_Float, Param_Cell);
 }
 
-void Call_OnReplaySaved(int client, int replayType, const char[] map, int course, int timeType, float time, const char[] filePath)
+Action Call_OnReplaySaved(int client, int replayType, const char[] map, int course, int timeType, float time, const char[] filePath, bool tempReplay)
 {
+	Action result;
 	Call_StartForward(H_OnReplaySaved);
 	Call_PushCell(client);
 	Call_PushCell(replayType);
@@ -47,7 +48,9 @@ void Call_OnReplaySaved(int client, int replayType, const char[] map, int course
 	Call_PushCell(timeType);
 	Call_PushFloat(time);
 	Call_PushString(filePath);
-	Call_Finish();
+	Call_PushCell(tempReplay);
+	Call_Finish(result);
+	return result;
 }
 
 void Call_OnReplayDiscarded(int client)

--- a/addons/sourcemod/scripting/gokz-replays/recording.sp
+++ b/addons/sourcemod/scripting/gokz-replays/recording.sp
@@ -6,11 +6,13 @@
 	of the last 2 minutes of their actions. If a player is banned
 	while their timer isn't running, those 2 minutes are saved.
 	If the player has their timer running, the recording is done from
-	the beginning of the run. If the player misses the server record,
+	the beginning of the run. If the player can no longer beat their PB,
 	then the recording goes back to only keeping track of the last
-	two minutes. Upon beating the server record, a binary file will be 
-	written with a 'header' containing information	about the run,
+	two minutes. Upon beating their PB, a temporary binary file will be 
+	written with a 'header' containing information about the run,
 	followed by the recorded tick data from OnPlayerRunCmdPost.
+	The binary file will be permanently locally saved on the server
+	if the run beats the server record.
 */
 
 static float tickrate;
@@ -20,7 +22,7 @@ static int recordingIndex[MAXPLAYERS + 1];
 static float playerSensitivity[MAXPLAYERS + 1];
 static float playerMYaw[MAXPLAYERS + 1];
 static bool isTeleportTick[MAXPLAYERS + 1];
-static bool timerRunning[MAXPLAYERS + 1];
+static ReplaySaveState replaySaveState[MAXPLAYERS + 1];
 static bool recordingPaused[MAXPLAYERS + 1];
 static bool postRunRecording[MAXPLAYERS + 1];
 static ArrayList recordedRecentData[MAXPLAYERS + 1];
@@ -121,7 +123,7 @@ void OnPlayerRunCmdPost_Recording(int client, int buttons, int tickCount, const 
 		isTeleportTick[client] = false;
 	}
 	
-	if (timerRunning[client])
+	if (replaySaveState[client] != ReplaySave_Disabled)
 	{
 		int runTick = GetArraySize(recordedRunData[client]);
 		recordedRunData[client].Resize(runTick + 1);
@@ -163,13 +165,13 @@ Action GOKZ_OnTimerStart_Recording(int client)
 
 void GOKZ_OnTimerStart_Post_Recording(int client)
 {
-	timerRunning[client] = true;
+	replaySaveState[client] = ReplaySave_Local;
 	StartRunRecording(client);
 }
 
 void GOKZ_OnTimerEnd_Recording(int client, int course, float time, int teleportsUsed)
 {
-	if (!timerRunning[client])
+	if (replaySaveState[client] == ReplaySave_Disabled)
 	{
 		return;
 	}
@@ -179,7 +181,7 @@ void GOKZ_OnTimerEnd_Recording(int client, int course, float time, int teleports
 	data.WriteCell(course);
 	data.WriteFloat(time);
 	data.WriteCell(teleportsUsed);
-
+	data.WriteCell(replaySaveState[client]);
 	// The previous run breather still did not finish, end it now or
 	// we will start overwriting the data.
 	if (runningRunBreatherTimer[client] != INVALID_HANDLE)
@@ -187,7 +189,7 @@ void GOKZ_OnTimerEnd_Recording(int client, int course, float time, int teleports
 		TriggerTimer(runningRunBreatherTimer[client], false);
 	}
 
-	timerRunning[client] = false;
+	replaySaveState[client] = ReplaySave_Disabled;
 	postRunRecording[client] = true;
 
 	// Swap recordedRunData and recordedPostRunData.
@@ -212,6 +214,7 @@ public Action Timer_EndRecording(Handle timer, DataPack data)
 	int course = data.ReadCell();
 	float time = data.ReadFloat();
 	int teleportsUsed = data.ReadCell();
+	ReplaySaveState saveState = data.ReadCell();
 	delete data;
 
 	// The client left after the run was done but before the post-run
@@ -227,12 +230,12 @@ public Action Timer_EndRecording(Handle timer, DataPack data)
 
 	if (gB_GOKZLocalDB && GOKZ_DB_IsCheater(client))
 	{
-		Call_OnTimerEnd_Post(client, "", course, time, teleportsUsed);
-		return Plugin_Stop;
+		// Replay might be submitted globally, but will not be saved locally.
+		saveState = ReplaySave_Temp;
 	}
 	
 	char path[PLATFORM_MAX_PATH];
-	if (SaveRecordingOfRun(path, client, course, time, teleportsUsed))
+	if (SaveRecordingOfRun(path, client, course, time, teleportsUsed, saveState == ReplaySave_Temp))
 	{
 		Call_OnTimerEnd_Post(client, path, course, time, teleportsUsed);
 	}
@@ -256,14 +259,14 @@ void GOKZ_OnResume_Recording(int client)
 
 void GOKZ_OnTimerStopped_Recording(int client)
 {
-	timerRunning[client] = false;
+	replaySaveState[client] = ReplaySave_Disabled;
 }
 
 void GOKZ_OnCountedTeleport_Recording(int client)
 {
 	if (gB_NubRecordMissed[client])
 	{
-		timerRunning[client] = false;
+		replaySaveState[client] = ReplaySave_Disabled;
 	}
 
 	isTeleportTick[client] = true;
@@ -271,10 +274,14 @@ void GOKZ_OnCountedTeleport_Recording(int client)
 
 void GOKZ_LR_OnRecordMissed_Recording(int client, int recordType)
 {
+	if (replaySaveState[client] == ReplaySave_Disabled)
+	{
+		return;
+	}
 	// If missed PRO record or both records, then can no longer beat a server record
 	if (recordType == RecordType_NubAndPro || recordType == RecordType_Pro)
 	{
-		timerRunning[client] = false;
+		replaySaveState[client] = ReplaySave_Temp;
 	}
 
 	// If on a NUB run and missed NUB record, then can no longer beat a server record
@@ -283,7 +290,30 @@ void GOKZ_LR_OnRecordMissed_Recording(int client, int recordType)
 	{
 		if (GOKZ_GetTeleportCount(client) > 0)
 		{
-			timerRunning[client] = false;
+			replaySaveState[client] = ReplaySave_Temp;
+		}
+	}
+}
+
+public void GOKZ_LR_OnPBMissed(int client, float pbTime, int course, int mode, int style, int recordType)
+{
+	if (replaySaveState[client] == ReplaySave_Disabled)
+	{
+		return;
+	}
+	// If missed PRO record or both records, then can no longer beat PB
+	if (recordType == RecordType_NubAndPro || recordType == RecordType_Pro)
+	{
+		replaySaveState[client] = ReplaySave_Disabled;
+	}
+
+	// If on a NUB run and missed NUB record, then can no longer beat PB
+	// Otherwise wait to see if they teleport before stopping the recording
+	if (recordType == RecordType_Nub)
+	{
+		if (GOKZ_GetTeleportCount(client) > 0)
+		{
+			replaySaveState[client] = ReplaySave_Disabled;
 		}
 	}
 }
@@ -355,7 +385,7 @@ static void ClearClientRecordingState(int client)
 	playerSensitivity[client] = -1.0;
 	playerMYaw[client] = -1.0;
 	isTeleportTick[client] = false;
-	timerRunning[client] = false;
+	replaySaveState[client] = ReplaySave_Disabled;
 	recordingPaused[client] = false;
 	postRunRecording[client] = false;
 	runningRunBreatherTimer[client] = INVALID_HANDLE;
@@ -436,7 +466,7 @@ static void ResumeRecording(int client)
 	recordingPaused[client] = false;
 }
 
-static bool SaveRecordingOfRun(char replayPath[PLATFORM_MAX_PATH], int client, int course, float time, int teleportsUsed)
+static bool SaveRecordingOfRun(char replayPath[PLATFORM_MAX_PATH], int client, int course, float time, int teleportsUsed, bool temp)
 {
 	// Prepare data
 	int timeType = GOKZ_GetTimeTypeEx(teleportsUsed);
@@ -452,12 +482,12 @@ static bool SaveRecordingOfRun(char replayPath[PLATFORM_MAX_PATH], int client, i
 	runHeader.teleportsUsed = teleportsUsed;
 
 	// Build path and create/overwrite associated file
-	FormatRunReplayPath(replayPath, sizeof(replayPath), course, generalHeader.mode, generalHeader.style, timeType);
+	FormatRunReplayPath(replayPath, sizeof(replayPath), course, generalHeader.mode, generalHeader.style, timeType, temp);
 	if (FileExists(replayPath))
 	{
 		DeleteFile(replayPath);
 	}
-	else
+	else if (!temp)
 	{
 		AddToReplayInfoCache(course, generalHeader.mode, generalHeader.style, timeType);
 		SortReplayInfoCache();
@@ -480,8 +510,11 @@ static bool SaveRecordingOfRun(char replayPath[PLATFORM_MAX_PATH], int client, i
 	WriteTickData(file, client, ReplayType_Run);
 
 	delete file;
-
-	Call_OnReplaySaved(client, ReplayType_Run, gC_CurrentMap, course, timeType, time, replayPath);
+	// If there is no plugin that wants to take over the replay file, we will delete it ourselves.
+	if (Call_OnReplaySaved(client, ReplayType_Run, gC_CurrentMap, course, timeType, time, replayPath, temp) != Plugin_Continue && temp)
+	{
+		DeleteFile(replayPath);
+	}
 
 	return true;
 }
@@ -728,12 +761,20 @@ static void WriteTickDataToFile(File file, bool isFirstTick, ReplayTickData tick
 	}
 }
 
-static void FormatRunReplayPath(char[] buffer, int maxlength, int course, int mode, int style, int timeType)
+static void FormatRunReplayPath(char[] buffer, int maxlength, int course, int mode, int style, int timeType, bool tempPath)
 {
+	// Use GetEngineTime to prevent accidental replay overrides.
+	// Technically it would still be possible to override this file by accident,
+	// if somehow the server restarts to this exact map and course, 
+	// and this function is run at the exact same time, but that is extremely unlikely.
+	// Also by then this file should have already been deleted.
+	char tempTimeString[32];
+	Format(tempTimeString, sizeof(tempTimeString), "%f_", GetEngineTime());
 	BuildPath(Path_SM, buffer, maxlength,
-		"%s/%s/%d_%s_%s_%s.%s",
-		RP_DIRECTORY_RUNS,
+		"%s/%s/%s%d_%s_%s_%s.%s",
+		tempPath ? RP_DIRECTORY_RUNS_TEMP : RP_DIRECTORY_RUNS,
 		gC_CurrentMap,
+		tempPath ? tempTimeString : "",
 		course,
 		gC_ModeNamesShort[mode], 
 		gC_StyleNamesShort[style], 

--- a/addons/sourcemod/scripting/gokz-replays/recording.sp
+++ b/addons/sourcemod/scripting/gokz-replays/recording.sp
@@ -511,7 +511,7 @@ static bool SaveRecordingOfRun(char replayPath[PLATFORM_MAX_PATH], int client, i
 
 	delete file;
 	// If there is no plugin that wants to take over the replay file, we will delete it ourselves.
-	if (Call_OnReplaySaved(client, ReplayType_Run, gC_CurrentMap, course, timeType, time, replayPath, temp) != Plugin_Continue && temp)
+	if (Call_OnReplaySaved(client, ReplayType_Run, gC_CurrentMap, course, timeType, time, replayPath, temp) == Plugin_Continue && temp)
 	{
 		DeleteFile(replayPath);
 	}

--- a/addons/sourcemod/scripting/include/gokz/replays.inc
+++ b/addons/sourcemod/scripting/include/gokz/replays.inc
@@ -29,6 +29,13 @@ enum
 	REPLAYTYPE_COUNT
 };
 
+enum ReplaySaveState
+{
+	ReplaySave_Local = 0,
+	ReplaySave_Temp,
+	ReplaySave_Disabled
+};
+
 // NOTE: Replays use delta compression for storage.
 // This enum is the indices of the ReplayTickData enum struct.
 // NOTE: This has to match the ReplayTickData enum struct!!!
@@ -121,6 +128,7 @@ enum struct ReplayTickData
 
 #define RP_DIRECTORY "data/gokz-replays" // In Path_SM
 #define RP_DIRECTORY_RUNS "data/gokz-replays/_runs" // In Path_SM
+#define RP_DIRECTORY_RUNS_TEMP "data/gokz-replays/_tempRuns" // In Path_SM
 #define RP_DIRECTORY_CHEATERS "data/gokz-replays/_cheaters" // In Path_SM
 #define RP_DIRECTORY_JUMPS "data/gokz-replays/_jumps" // In Path_SM
 #define RP_DIRECTORY_BLOCKJUMPS "blocks"
@@ -178,8 +186,10 @@ enum struct ReplayTickData
  * @param timeType			The type of time (Pro/Nub).
  * @param time				The time the run was completed in.
  * @param filePath			Replay file path.
+ * @param tempReplay		Whether the replay file should only be temporaily stored. 
+ * @return					Plugin_Handled to take over the temporary replay deletion, Plugin_Continue to allow temporary replay deletion by the replay plugin.
  */
-forward void GOKZ_RP_OnReplaySaved(int client, int replayType, const char[] map, int course, int timeType, float time, const char[] filePath);
+forward Action GOKZ_RP_OnReplaySaved(int client, int replayType, const char[] map, int course, int timeType, float time, const char[] filePath, bool tempReplay);
 
 /**
  * Called when a currently being recorded replay is discarded from


### PR DESCRIPTION
Resolves #323.
Right now a run will only gets uploaded if it beats the server record. Now it will be uploaded if it beats the player's PB instead.

It is possible to get the world record without beating the server record (eg. map exists before it gets global). This should also be useful for cheated run checks, as not every cheated run would beat SR.

I haven't (couldn't) tested this out as it is not possible for me to do so without staging API access.