### PR TITLE
Add dynamic menu, add checkpoint and hud related natives, loadloc now forces TP menu update, add generic error messages for pause/resume

### DIFF
--- a/addons/sourcemod/scripting/gokz-core/natives.sp
+++ b/addons/sourcemod/scripting/gokz-core/natives.sp
@@ -25,6 +25,7 @@ void CreateNatives()
 	CreateNative("GOKZ_GetStartPositionType", Native_GetStartPositionType);
 	CreateNative("GOKZ_SetStartPositionToMapStart", Native_SetStartPositionToMapStart);
 	CreateNative("GOKZ_MakeCheckpoint", Native_MakeCheckpoint);
+	CreateNative("GOKZ_GetCanMakeCheckpoint", Native_GetCanMakeCheckpoint);
 	CreateNative("GOKZ_TeleportToCheckpoint", Native_TeleportToCheckpoint);
 	CreateNative("GOKZ_GetCanTeleportToCheckpoint", Native_GetCanTeleportToCheckpoint);
 	CreateNative("GOKZ_PrevCheckpoint", Native_PrevCheckpoint);
@@ -36,6 +37,7 @@ void CreateNatives()
 	CreateNative("GOKZ_Pause", Native_Pause);
 	CreateNative("GOKZ_GetCanPause", Native_GetCanPause);
 	CreateNative("GOKZ_Resume", Native_Resume);
+	CreateNative("GOKZ_GetCanResume", Native_GetCanResume);
 	CreateNative("GOKZ_TogglePause", Native_TogglePause);
 	CreateNative("GOKZ_PlayErrorSound", Native_PlayErrorSound);
 	CreateNative("GOKZ_SetValidJumpOrigin", Native_SetValidJumpOrigin);
@@ -272,6 +274,11 @@ public int Native_MakeCheckpoint(Handle plugin, int numParams)
 	MakeCheckpoint(GetNativeCell(1));
 }
 
+public int Native_GetCanMakeCheckpoint(Handle plugin, int numParams)
+{
+	return CanMakeCheckpoint(GetNativeCell(1));
+}
+
 public int Native_TeleportToCheckpoint(Handle plugin, int numParams)
 {
 	TeleportToCheckpoint(GetNativeCell(1));
@@ -325,6 +332,11 @@ public int Native_GetCanPause(Handle plugin, int numParams)
 public int Native_Resume(Handle plugin, int numParams)
 {
 	Resume(GetNativeCell(1));
+}
+
+public int Native_GetCanResume(Handle plugin, int numParams)
+{
+	return CanResume(GetNativeCell(1));
 }
 
 public int Native_TogglePause(Handle plugin, int numParams)

--- a/addons/sourcemod/scripting/gokz-hud.sp
+++ b/addons/sourcemod/scripting/gokz-hud.sp
@@ -33,6 +33,7 @@ bool gB_GOKZReplays;
 bool gB_MenuShowing[MAXPLAYERS + 1];
 bool gB_JBTakeoff[MAXPLAYERS + 1];
 bool gB_FastUpdateRate[MAXPLAYERS + 1];
+bool gB_DynamicMenu[MAXPLAYERS + 1];
 
 #include "gokz-hud/commands.sp"
 #include "gokz-hud/hide_weapon.sp"
@@ -44,13 +45,14 @@ bool gB_FastUpdateRate[MAXPLAYERS + 1];
 #include "gokz-hud/speed_text.sp"
 #include "gokz-hud/timer_text.sp"
 #include "gokz-hud/tp_menu.sp"
-
+#include "gokz-hud/natives.sp"
 
 // =====[ PLUGIN EVENTS ]=====
 
 public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max)
 {
 	RegPluginLibrary("gokz-hud");
+	CreateNatives();
 	return APLRes_Success;
 }
 
@@ -240,12 +242,17 @@ public void GOKZ_OnOptionChanged(int client, const char[] option, any newValue)
 		{
 			gB_FastUpdateRate[client] = GOKZ_HUD_GetOption(client, HUDOption_UpdateRate) == UpdateRate_Fast;
 		}
+		else if (hudOption == HUDOption_DynamicMenu)
+		{
+			gB_DynamicMenu[client] = GOKZ_HUD_GetOption(client, HUDOption_DynamicMenu) == DynamicMenu_Enabled;
+		}
 	}
 }
 
 public void GOKZ_OnOptionsLoaded(int client)
 {
 	gB_FastUpdateRate[client] = GOKZ_HUD_GetOption(client, HUDOption_UpdateRate) == UpdateRate_Fast;
+	gB_DynamicMenu[client] = GOKZ_HUD_GetOption(client, HUDOption_DynamicMenu) == DynamicMenu_Enabled;
 }
 
 // =====[ OTHER EVENTS ]=====

--- a/addons/sourcemod/scripting/gokz-hud/natives.sp
+++ b/addons/sourcemod/scripting/gokz-hud/natives.sp
@@ -1,0 +1,9 @@
+void CreateNatives()
+{
+	CreateNative("GOKZ_HUD_ForceUpdateTPMenu", Native_ForceUpdateTPMenu);
+}
+
+public int Native_ForceUpdateTPMenu(Handle plugin, int numParams)
+{
+	SetForceUpdateTPMenu(GetNativeCell(1));
+}

--- a/addons/sourcemod/scripting/gokz-hud/options.sp
+++ b/addons/sourcemod/scripting/gokz-hud/options.sp
@@ -154,5 +154,19 @@ static void PrintOptionChangeMessage(int client, HUDOption option, any newValue)
 				}
 			}
 		}
+		case HUDOption_DynamicMenu:
+		{
+			switch (newValue)
+			{
+				case DynamicMenu_Disabled:
+				{
+					GOKZ_PrintToChat(client, true, "%t", "Option - Dynamic Menu - Disable");
+				}
+				case DynamicMenu_Enabled:
+				{
+					GOKZ_PrintToChat(client, true, "%t", "Option - Dynamic Menu - Enable");
+				}
+			}
+		}
 	}
 } 

--- a/addons/sourcemod/scripting/gokz-hud/options_menu.sp
+++ b/addons/sourcemod/scripting/gokz-hud/options_menu.sp
@@ -138,6 +138,12 @@ public void TopMenuHandler_HUD(TopMenu topmenu, TopMenuAction action, TopMenuObj
 					gC_HUDOptionPhrases[option], param,
 					gC_ShowSpecsPhrases[GOKZ_HUD_GetOption(param, option)], param);
 			}
+			case HUDOption_DynamicMenu:
+			{
+				FormatEx(buffer, maxlength, "%T - %T",
+					gC_HUDOptionPhrases[option], param,
+					gC_DynamicMenuPhrases[GOKZ_HUD_GetOption(param, option)], param);
+			}
 			default:FormatToggleableOptionDisplay(param, option, buffer, maxlength);
 		}
 	}

--- a/addons/sourcemod/scripting/gokz-saveloc.sp
+++ b/addons/sourcemod/scripting/gokz-saveloc.sp
@@ -9,7 +9,7 @@
 #undef REQUIRE_EXTENSIONS
 #undef REQUIRE_PLUGIN
 #include <updater>
-
+#include <gokz/hud>
 #pragma newdecls required
 #pragma semicolon 1
 
@@ -135,7 +135,7 @@ bool gB_LocMenuOpen[MAXPLAYERS + 1];
 bool gB_UsedLoc[MAXPLAYERS + 1];
 int gI_MostRecentLocation[MAXPLAYERS + 1];
 
-
+bool gB_GOKZHUD;
 
 // =====[ PLUGIN EVENTS ]=====
 
@@ -160,6 +160,7 @@ public void OnAllPluginsLoaded()
 	{
 		Updater_AddPlugin(UPDATER_URL);
 	}
+	gB_GOKZHUD = LibraryExists("gokz-hud");
 }
 
 public void OnLibraryAdded(const char[] name)
@@ -168,6 +169,12 @@ public void OnLibraryAdded(const char[] name)
 	{
 		Updater_AddPlugin(UPDATER_URL);
 	}
+	gB_GOKZHUD = gB_GOKZHUD || StrEqual(name, "gokz-hud");
+}
+
+public void OnLibraryRemoved(const char[] name)
+{
+	gB_GOKZHUD = gB_GOKZHUD && !StrEqual(name, "gokz-hud");
 }
 
 public void OnMapStart()
@@ -605,6 +612,10 @@ bool LoadLocation(int client, int id)
 	if (loc.Load(client))
 	{
 		gB_UsedLoc[client] = true;
+		if (gB_GOKZHUD)
+		{
+			GOKZ_HUD_ForceUpdateTPMenu(client);
+		}
 	}
 	// print message if loading new location
 	if (gI_MostRecentLocation[client] != id)

--- a/addons/sourcemod/scripting/include/gokz/core.inc
+++ b/addons/sourcemod/scripting/include/gokz/core.inc
@@ -1206,6 +1206,13 @@ native void GOKZ_TeleportToEnd(int client, int course);
 native void GOKZ_MakeCheckpoint(int client);
 
 /**
+ * Gets whether a player can make a new checkpoint.
+ * @param client		Client index.
+ * @return				Whether player can set a checkpoint.
+ */
+native bool GOKZ_GetCanMakeCheckpoint(int client);
+
+/**
  * Teleports a player to their last checkpoint.
  *
  * @param client    	Client index.
@@ -1290,6 +1297,14 @@ native bool GOKZ_GetCanPause(int client);
  * @param client    	Client index.
  */
 native void GOKZ_Resume(int client);
+
+/**
+ * Gets whether a player can resume. Resuming is not allowed
+ * under some circumstance when the timer is running.
+ *
+ * @param client    	Client index.
+ */
+native bool GOKZ_GetCanResume(int client);
 
 /**
  * Toggles the paused state of a player.
@@ -1737,6 +1752,7 @@ public void __pl_gokz_core_SetNTVOptional()
 	MarkNativeAsOptional("GOKZ_SetStartPositionToMapStart");
 	MarkNativeAsOptional("GOKZ_TeleportToEnd");
 	MarkNativeAsOptional("GOKZ_MakeCheckpoint");
+	MarkNativeAsOptional("GOKZ_GetCanMakeCheckpoint");
 	MarkNativeAsOptional("GOKZ_TeleportToCheckpoint");
 	MarkNativeAsOptional("GOKZ_GetCanTeleportToCheckpoint");
 	MarkNativeAsOptional("GOKZ_PrevCheckpoint");
@@ -1748,6 +1764,7 @@ public void __pl_gokz_core_SetNTVOptional()
 	MarkNativeAsOptional("GOKZ_Pause");
 	MarkNativeAsOptional("GOKZ_GetCanPause");
 	MarkNativeAsOptional("GOKZ_Resume");
+	MarkNativeAsOptional("GOKZ_GetCanResume");
 	MarkNativeAsOptional("GOKZ_TogglePause");
 	MarkNativeAsOptional("GOKZ_PlayErrorSound");
 	MarkNativeAsOptional("GOKZ_SetValidJumpOrigin");

--- a/addons/sourcemod/scripting/include/gokz/hud.inc
+++ b/addons/sourcemod/scripting/include/gokz/hud.inc
@@ -28,6 +28,7 @@ enum HUDOption:
 	HUDOption_DeadstrafeColor,
 	HUDOption_UpdateRate,
 	HUDOption_ShowSpectators,
+	HUDOption_DynamicMenu,
 	HUDOPTION_COUNT
 };
 
@@ -123,6 +124,13 @@ enum
 	UPDATERATE_COUNT,
 };
 
+enum
+{
+	DynamicMenu_Disabled = 0,
+	DynamicMenu_Enabled,
+	DYNAMICMENU_COUNT
+};
+
 // =====[ STRUCTS ]======
 
 enum struct HUDInfo
@@ -168,7 +176,8 @@ stock char gC_HUDOptionNames[HUDOPTION_COUNT][] =
 	"GOKZ HUD - Show Controls",
 	"GOKZ HUD - Dead Strafe",
 	"GOKZ HUD - Update Rate",
-	"GOKZ HUD - Show Spectators"
+	"GOKZ HUD - Show Spectators",
+	"GOKZ HUD - Dynamic Menu"
 };
 
 stock char gC_HUDOptionDescriptions[HUDOPTION_COUNT][] = 
@@ -184,7 +193,8 @@ stock char gC_HUDOptionDescriptions[HUDOPTION_COUNT][] =
 	"Replay Controls Display - 0 = Disbled, 1 = Enabled",
 	"Dead Strafe Indicator - 0 = Disabled, 1 = Enabled",
 	"HUD Update Rate - 0 = Slow, 1 = Fast",
-	"Show Spectators - 0 = Disabled, 1 = Number Only, 2 = Number and Names"
+	"Show Spectators - 0 = Disabled, 1 = Number Only, 2 = Number and Names",
+	"Dynamic Menu - 0 = Disabled, 1 = Enabled"
 };
 
 stock char gC_HUDOptionPhrases[HUDOPTION_COUNT][] = 
@@ -200,7 +210,8 @@ stock char gC_HUDOptionPhrases[HUDOPTION_COUNT][] =
 	"Options Menu - Show Controls",
 	"Options Menu - Dead Strafe Indicator",
 	"Options Menu - Update Rate",
-	"Options Menu - Show Spectators"
+	"Options Menu - Show Spectators",
+	"Options Menu - Dynamic Menu"
 };
 
 stock int gI_HUDOptionCounts[HUDOPTION_COUNT] = 
@@ -216,7 +227,8 @@ stock int gI_HUDOptionCounts[HUDOPTION_COUNT] =
 	REPLAYCONTROLS_COUNT,
 	DEADSTRAFECOLOR_COUNT,
 	UPDATERATE_COUNT,
-	SHOWSPECS_COUNT
+	SHOWSPECS_COUNT,
+	DYNAMICMENU_COUNT
 };
 
 stock int gI_HUDOptionDefaults[HUDOPTION_COUNT] = 
@@ -232,7 +244,8 @@ stock int gI_HUDOptionDefaults[HUDOPTION_COUNT] =
 	ReplayControls_Enabled,
 	DeadstrafeColor_Disabled,
 	UpdateRate_Slow,
-	ShowSpecs_Disabled
+	ShowSpecs_Disabled,
+	DynamicMenu_Disabled
 };
 
 stock char gC_TPMenuPhrases[TPMENU_COUNT][] = 
@@ -295,6 +308,21 @@ stock char gC_HUDUpdateRatePhrases[UPDATERATE_COUNT][]=
 	"Options Menu - Slow",
 	"Options Menu - Fast"
 };
+
+stock char gC_DynamicMenuPhrases[UPDATERATE_COUNT][]=
+{
+	"Options Menu - Disabled",
+	"Options Menu - Enabled"
+};
+
+// =====[ NATIVES ]=====
+
+/**
+ * Force the client's TP menu to update.
+ *
+ * @param client		Client index.
+ */
+native void GOKZ_HUD_ForceUpdateTPMenu(int client);
 
 // =====[ STOCKS ]=====
 
@@ -384,3 +412,10 @@ public SharedPlugin __pl_gokz_hud =
 	required = 0, 
 	#endif
 };
+
+#if !defined REQUIRE_PLUGIN
+public void __pl_gokz_hud_SetNTVOptional()
+{
+	MarkNativeAsOptional("GOKZ_HUD_ForceUpdateTPMenu");
+}
+#endif

--- a/addons/sourcemod/scripting/include/gokz/kzplayer.inc
+++ b/addons/sourcemod/scripting/include/gokz/kzplayer.inc
@@ -106,6 +106,12 @@ methodmap KZPlayer < MovementAPIPlayer {
 		GOKZ_MakeCheckpoint(this.ID);
 	}
 	
+	property bool CanMakeCheckpoint {
+		public get() {
+			return GOKZ_GetCanMakeCheckpoint(this.ID);
+		}
+	}
+
 	public void TeleportToCheckpoint() {
 		GOKZ_TeleportToCheckpoint(this.ID);
 	}
@@ -158,6 +164,12 @@ methodmap KZPlayer < MovementAPIPlayer {
 	
 	public void Resume() {
 		GOKZ_Resume(this.ID);
+	}
+	
+	property bool CanResume {
+		public get() {
+			return GOKZ_GetCanResume(this.ID);
+		}
 	}
 	
 	public void TogglePause() {
@@ -439,6 +451,14 @@ methodmap KZPlayer < MovementAPIPlayer {
 		}
 	}
 	
+	property int DynamicMenu {
+		public get() {
+			return this.GetHUDOption(HUDOption_DynamicMenu);
+		}
+		public set(int value) {
+			this.SetHUDOption(HUDOption_DynamicMenu, value);
+		}
+	}
 	#endif
 	// =====[ END HUD ]=====
 	

--- a/addons/sourcemod/translations/gokz-core.phrases.txt
+++ b/addons/sourcemod/translations/gokz-core.phrases.txt
@@ -119,6 +119,10 @@
 	{
 		"en"		"{darkred}You can't undo because you teleported while in an anti-checkpoint zone."
 	}
+	"Can't Pause (Generic)"
+	{
+		"en"		"{darkred}You can't pause right now."
+	}
 	"Can't Pause (Just Resumed)"
 	{
 		"en"		"{darkred}You can't pause because you just resumed."
@@ -139,6 +143,10 @@
 	"Can't Pause (Anti Pause Area)"
 	{
 		"en"		"{darkred}You can't pause because pausing is disabled in this area."
+	}
+	"Can't Pause (Generic)"
+	{
+		"en"		"{darkred}You can't resume right now."
 	}
 	"Can't Resume (Just Paused)"
 	{

--- a/addons/sourcemod/translations/gokz-hud.phrases.txt
+++ b/addons/sourcemod/translations/gokz-hud.phrases.txt
@@ -91,6 +91,14 @@
 	{
 		"en"		"{grey}Number and names of spectators are now shown."
 	}
+	"Option - Dynamic Menu - Disable"
+	{
+		"en"		"{grey}Dynamic menu disabled."
+	}
+	"Option - Dynamic Menu - Enable"
+	{
+		"en"		"{grey}Dynamic menu enabled. Unavailable options will be greyed out. This option is not recommended with high latency!"
+	}
 
 
 	// =====[ INFO PANEL ]=====
@@ -280,7 +288,10 @@
 	{
 		"en"		"Number and Names"
 	}
-
+	"Options Menu - Dynamic Menu"
+	{
+		"en"		"Dynamic menu"
+	}
 
 	// =====[ RACING ]=====
 	"Get Ready"

--- a/cfg/sourcemod/gokz/options_menu_sorting.cfg
+++ b/cfg/sourcemod/gokz/options_menu_sorting.cfg
@@ -25,6 +25,7 @@
 	{
 		"item"		"GOKZ HUD - Update Rate"
 		"item"		"GOKZ HUD - Teleport Menu"
+		"item"		"GOKZ HUD - Dynamic Menu"
 		"item"		"GOKZ HUD - Centre Panel"
 		"item"		"GOKZ HUD - Timer Text"
 		"item"		"GOKZ HUD - Timer Style"


### PR DESCRIPTION
Hopefully resolves #339. 

Dynamic menu is useful for the players to know if CP/TP/Pause is possible or not during a run, but might not work very well with high ping.