### PR TITLE
Stop the recording if its duration is too long

### DIFF
--- a/addons/sourcemod/scripting/gokz-replays/recording.sp
+++ b/addons/sourcemod/scripting/gokz-replays/recording.sp
@@ -124,15 +124,24 @@ void OnPlayerRunCmdPost_Recording(int client, int buttons, int tickCount, const 
 	if (timerRunning[client])
 	{
 		int runTick = GetArraySize(recordedRunData[client]);
-		recordedRunData[client].Resize(runTick + 1);
-		recordedRunData[client].SetArray(runTick, tickData);
+		if (runTick < RP_MAX_DURATION)
+		{
+			// Resize might fail if the timer exceed the max duration,
+			// as it is not guaranteed to allocate more than 1GB of contiguous memory,
+			// causing mass lag spikes that kick everyone out of the server.
+			// We can still attempt to save the rest of the recording though.
+			recordedRunData[client].Resize(runTick + 1);
+			recordedRunData[client].SetArray(runTick, tickData);
+		}
 	}
-
 	if (postRunRecording[client])
 	{
 		int tick = GetArraySize(recordedPostRunData[client]);
-		recordedPostRunData[client].Resize(tick + 1);
-		recordedPostRunData[client].SetArray(tick, tickData);
+		if (tick < RP_MAX_DURATION)
+		{
+			recordedPostRunData[client].Resize(tick + 1);
+			recordedPostRunData[client].SetArray(tick, tickData);
+		}
 	}
 	
 	int tick = recordingIndex[client];

--- a/addons/sourcemod/scripting/include/gokz/replays.inc
+++ b/addons/sourcemod/scripting/include/gokz/replays.inc
@@ -136,7 +136,7 @@ enum struct ReplayTickData
 #define RP_MAX_CHEATER_REPLAY_LENGTH 120 // 2 minutes
 #define RP_MAX_BHOP_GROUND_TICKS 5
 #define RP_SKIP_TIME 10 // 10 seconds
-
+#define RP_MAX_DURATION 6451200 // 14 hours on 128 tick
 
 #define RP_MOVETYPE_MASK		(0xF)
 #define RP_IN_ATTACK			(1 << 4)


### PR DESCRIPTION
Resolves #337.
The timer can reach up to 29 hours before failing, but it can fail as early as 14.5 hours, so I chose the 14 hours mark as the limit.