### PR TITLE
When your timer is running, then don't restart the timer if you try to start a run on a different course

### DIFF
--- a/addons/sourcemod/scripting/gokz-core/timer/timer.sp
+++ b/addons/sourcemod/scripting/gokz-core/timer/timer.sp
@@ -59,7 +59,8 @@ bool TimerStart(int client, int course, bool allowMidair = false, bool playSound
 		 || JustNoclipped(client)
 		 || !IsPlayerValidMoveType(client)
 		 || !allowMidair && (!Movement_GetOnGround(client) || JustLanded(client))
-		 || allowMidair && !Movement_GetOnGround(client) && (!GOKZ_GetValidJump(client) || GOKZ_GetHitPerf(client)))
+		 || allowMidair && !Movement_GetOnGround(client) && (!GOKZ_GetValidJump(client) || GOKZ_GetHitPerf(client))
+		 || (GOKZ_GetTimerRunning(client) && GOKZ_GetCourse(client) != course))
 	{
 		return false;
 	}


### PR DESCRIPTION
This is a QOL feature. Mainly fixes the problem when players would accidentally press a bonus start button/trigger a bonus start zone while doing a run.
This could be a bit confusing for players who actually want to start a timer, though so a message would be nice, but I'm lazy.