### PR TITLE
Fix hud errors related to replay playback

### DIFF
--- a/addons/sourcemod/scripting/gokz-hud.sp
+++ b/addons/sourcemod/scripting/gokz-hud.sp
@@ -157,6 +157,11 @@ public void OnPlayerRunCmdPost(int client, int buttons, int impulse, const float
 		return;
 	}
 
+	if (!IsValidClient(info.ID))
+	{
+		return;
+	}
+	
 	OnPlayerRunCmdPost_InfoPanel(client, cmdnum, info);
 	OnPlayerRunCmdPost_RacingText(client, cmdnum);
 	OnPlayerRunCmdPost_SpeedText(client, cmdnum, info);


### PR DESCRIPTION
Fix gokz-hud spewing errors at the end of replay playback, as the replay bot is kicked off the server.