### PR TITLE
Fix replay bots joining the incorrect teams, fix OnLadder HudInfo not being correct

### DIFF
--- a/addons/sourcemod/scripting/gokz-replays/playback.sp
+++ b/addons/sourcemod/scripting/gokz-replays/playback.sp
@@ -44,6 +44,7 @@ static int timeInAir[RP_MAX_BOTS];
 static int botTeleportsUsed[RP_MAX_BOTS];
 static int botCurrentTeleport[RP_MAX_BOTS];
 static int botButtons[RP_MAX_BOTS];
+static MoveType botMoveType[RP_MAX_BOTS];
 static float botTakeoffSpeed[RP_MAX_BOTS];
 static float botSpeed[RP_MAX_BOTS];
 static float botLastOrigin[RP_MAX_BOTS][3];
@@ -58,12 +59,12 @@ static float botLandingSpeed[RP_MAX_BOTS];
 // =====[ PUBLIC ]=====
 
 // Returns the client index of the replay bot, or -1 otherwise
-int LoadReplayBot(int client, char[] path)
+int LoadReplayBot(int client, char[] path, int timeType = -1)
 {
 	int bot;
 	if (GetBotsInUse() < RP_MAX_BOTS)
 	{
-		bot = GetUnusedBot();
+		bot = GetUnusedBot(timeType);
 	}
 	else
 	{
@@ -127,7 +128,7 @@ void GetPlaybackState(int client, HUDInfo info)
 	info.TimeType = botTeleportsUsed[bot] > 0 ? TimeType_Nub : TimeType_Pro;
 	info.Speed = botSpeed[bot];
 	info.Paused = false;
-	info.OnLadder = false;
+	info.OnLadder = (botMoveType[bot] == MOVETYPE_LADDER);
 	info.Noclipping = false;
 	info.OnGround = Movement_GetOnGround(client);
 	info.Ducking = botButtons[bot] & IN_DUCK > 0;
@@ -1001,6 +1002,7 @@ void PlaybackVersion2(int client, int bot, int &buttons)
 		int entityFlags = GetEntityFlags(client);
 		// Set the bot's MoveType
 		MoveType replayMoveType = view_as<MoveType>(currentTickData.flags & RP_MOVETYPE_MASK);
+		botMoveType[bot] = replayMoveType;
 		if (Movement_GetSpeed(client) > SPEED_NORMAL * 2)
 		{
 			Movement_SetMovetype(client, MOVETYPE_NOCLIP);
@@ -1249,15 +1251,14 @@ static int GetBotsInUse()
 }
 
 // Returns a bot that isn't currently replaying, or -1 if no unused bots found
-static int GetUnusedBot()
+static int GetUnusedBot(int timeType = -1)
 {
 	for (int bot = 0; bot < RP_MAX_BOTS; bot++)
 	{
 		if (!botInGame[bot])
 		{
 			// Set the bot's team based on if it's NUB or PRO
-			if (botReplayType[bot] == ReplayType_Run 
-				&& GOKZ_GetTimeTypeEx(botTeleportsUsed[bot]) == TimeType_Pro)
+			if (timeType == TimeType_Pro)
 			{
 				ServerCommand("bot_add_ct");
 			}

--- a/addons/sourcemod/scripting/gokz-replays/replay_menu.sp
+++ b/addons/sourcemod/scripting/gokz-replays/replay_menu.sp
@@ -69,7 +69,7 @@ public int MenuHandler_Replay(Menu menu, MenuAction action, int param1, int para
 			}
 		}
 		
-		LoadReplayBot(param1, path);
+		LoadReplayBot(param1, path, replayInfo[3]);
 	}
 	else if (action == MenuAction_Cancel)
 	{


### PR DESCRIPTION
`botReplayType[bot]` and `botTeleportsUsed[bot]` is not loaded in yet by the time the bot gets added.

`info.OnLadder` is now correct, and is necessary for dead strafe indicator to work properly. The indicator still doesn't work well with old replays because they didn't track movetypes.