### PR TITLE
Fix unresponsive client menu when players use start timer button zone, fix errors showing up if players try to pause in start timer button zone

### DIFF
--- a/addons/sourcemod/scripting/gokz-core/timer/pause.sp
+++ b/addons/sourcemod/scripting/gokz-core/timer/pause.sp
@@ -107,13 +107,13 @@ bool CanPause(int client, bool showError = false)
 	return true;
 }
 
-void Resume(int client)
+void Resume(int client, bool force = false)
 {
 	if (!paused[client])
 	{
 		return;
 	}
-	if (!CanResume(client, true))
+	if (!force && !CanResume(client, true))
 	{
 		return;
 	}
@@ -193,7 +193,7 @@ void OnTimerStart_Pause(int client)
 {
 	hasPausedInThisRun[client] = false;
 	hasResumedInThisRun[client] = false;
-	GOKZ_Resume(client);
+	Resume(client, true);
 }
 
 void OnChangeMovetype_Pause(int client, MoveType newMovetype)

--- a/addons/sourcemod/scripting/gokz-core/timer/timer.sp
+++ b/addons/sourcemod/scripting/gokz-core/timer/timer.sp
@@ -73,12 +73,6 @@ bool TimerStart(int client, int course, bool allowMidair = false, bool playSound
 		return false;
 	}
 
-	// Unpause the player, if they're paused
-	if (GOKZ_GetPaused(client))
-	{
-		GOKZ_Resume(client);
-	}
-	
 	// Prevent noclip exploit
 	SetEntProp(client, Prop_Send, "m_CollisionGroup", GOKZ_COLLISION_GROUP_STANDARD);
 

--- a/addons/sourcemod/scripting/gokz-hud/menu.sp
+++ b/addons/sourcemod/scripting/gokz-hud/menu.sp
@@ -33,7 +33,11 @@ void OnOptionChanged_Menu(int client, HUDOption option)
 
 void OnTimerStart_Menu(int client)
 {
-	CancelGOKZHUDMenu(client);
+	// Prevent the menu from getting cancelled every tick if player use start timer button zone.
+	if (GOKZ_GetTime(client) > 0.0)
+	{
+		CancelGOKZHUDMenu(client);
+	}
 }
 
 void OnTimerEnd_Menu(int client)
@@ -73,5 +77,9 @@ void OnJoinTeam_Menu(int client)
 
 void OnStartPositionSet_Menu(int client)
 {
-	CancelGOKZHUDMenu(client);
+	// Prevent the menu from getting cancelled every tick if player use start timer button zone.
+	if (GOKZ_GetTime(client) > 0.0)
+	{
+		CancelGOKZHUDMenu(client);
+	}
 } 


### PR DESCRIPTION
The client menu works half of the time when the players use start timer button zone,