### PR TITLE
Initialize replay datapack

### DIFF
--- a/addons/sourcemod/scripting/gokz-global/send_run.sp
+++ b/addons/sourcemod/scripting/gokz-global/send_run.sp
@@ -121,7 +121,7 @@ bool IsReplayReadyToSend(int client, int course, int timeType, float time)
 
 public void SendReplay(int client)
 {
-	DataPack dp;
+	DataPack dp = new DataPack();
 	dp.WriteString(deleteRecord[client] ? storedReplayPath[client] : "");
 	GlobalAPI_CreateReplayForRecordId(SendReplayCallback, dp, lastRecordId[client], storedReplayPath[client]);
 	lastRecordId[client] = -1;


### PR DESCRIPTION
This might fix the error that prevents replays from being sent to the API. This got through my testing because, well, I don't have access to the staging API.