### PR TITLE
Reduce lag spikes upon player spawn

### DIFF
--- a/addons/sourcemod/scripting/gokz-core.sp
+++ b/addons/sourcemod/scripting/gokz-core.sp
@@ -384,6 +384,13 @@ public Action OnNormalSound(int clients[MAXPLAYERS], int &numClients, char sampl
 
 public void OnEntityCreated(int entity, const char[] classname)
 {
+	// Don't react to player related entities
+	if (StrEqual(classname, "predicted_viewmodel")
+		|| StrEqual(classname, "cs_bot") || StrEqual(classname, "player")
+		|| StrContains(classname, "weapon") != -1)
+	{
+		return;
+	}
 	SDKHook(entity, SDKHook_Spawn, OnEntitySpawned);
 	SDKHook(entity, SDKHook_SpawnPost, OnEntitySpawnedPost);
 	OnEntityCreated_Triggerfix(entity, classname);

--- a/addons/sourcemod/scripting/gokz-core.sp
+++ b/addons/sourcemod/scripting/gokz-core.sp
@@ -385,7 +385,7 @@ public Action OnNormalSound(int clients[MAXPLAYERS], int &numClients, char sampl
 public void OnEntityCreated(int entity, const char[] classname)
 {
 	// Don't react to player related entities
-	if (StrEqual(classname, "predicted_viewmodel")
+	if (StrEqual(classname, "predicted_viewmodel") || StrEqual(classname, "item_assaultsuit")
 		|| StrEqual(classname, "cs_bot") || StrEqual(classname, "player")
 		|| StrContains(classname, "weapon") != -1)
 	{


### PR DESCRIPTION
This function only works on for triggers/buttons, hooking player entities just causes lag spikes and nothing else.
