### PR TITLE
Add late loading support for gokz-quiet, block extra sounds with !hide

### DIFF
--- a/addons/sourcemod/scripting/gokz-quiet.sp
+++ b/addons/sourcemod/scripting/gokz-quiet.sp
@@ -29,6 +29,7 @@ public Plugin myinfo =
 // Search for "coopcementplant.missionselect_blank" id with sv_soundscape_printdebuginfo.
 #define BLANK_SOUNDSCAPEINDEX 482
 #define EFFECT_IMPACT 8
+#define EFFECT_KNIFESLASH 2
 
 TopMenu gTM_Options;
 TopMenuObject gTMO_CatGeneral;
@@ -281,7 +282,7 @@ public Action Hook_EffectDispatch(const char[] te_name, const int[] players, int
 {
 	// Block bullet impact effects.
 	int effIndex = TE_ReadNum("m_iEffectName");
-	if (effIndex != EFFECT_IMPACT)
+	if (effIndex != EFFECT_IMPACT && effIndex != EFFECT_KNIFESLASH)
 	{
 		return Plugin_Continue;
 	}


### PR DESCRIPTION
Previously when someone spawns, you can still hear the armor equip and ammo pickup sounds, the knife hitting the ground sound, and the blood sound if the someone shoots you, even with `!hide` on.

This fixes that and adds late loading support as well.