### PR TITLE
Fix plugin source urls

### DIFF
--- a/addons/sourcemod/scripting/gokz-anticheat.sp
+++ b/addons/sourcemod/scripting/gokz-anticheat.sp
@@ -25,7 +25,7 @@ public Plugin myinfo =
 	author = "DanZay", 
 	description = "Detects basic player movement cheats", 
 	version = GOKZ_VERSION, 
-	url = "https://bitbucket.org/kztimerglobalteam/gokz"
+	url = GOKZ_SOURCE_URL
 };
 
 #define UPDATER_URL GOKZ_UPDATER_BASE_URL..."gokz-anticheat.txt"

--- a/addons/sourcemod/scripting/gokz-chat.sp
+++ b/addons/sourcemod/scripting/gokz-chat.sp
@@ -23,7 +23,7 @@ public Plugin myinfo =
 	author = "DanZay", 
 	description = "Handles client-triggered chat messages", 
 	version = GOKZ_VERSION, 
-	url = "https://bitbucket.org/kztimerglobalteam/gokz"
+	url = GOKZ_SOURCE_URL
 };
 
 #define UPDATER_URL GOKZ_UPDATER_BASE_URL..."gokz-chat.txt"

--- a/addons/sourcemod/scripting/gokz-core.sp
+++ b/addons/sourcemod/scripting/gokz-core.sp
@@ -31,7 +31,7 @@ public Plugin myinfo =
 	author = "DanZay", 
 	description = "Core plugin of the GOKZ plugin set", 
 	version = GOKZ_VERSION, 
-	url = "https://bitbucket.org/kztimerglobalteam/gokz"
+	url = GOKZ_SOURCE_URL
 };
 
 #define UPDATER_URL GOKZ_UPDATER_BASE_URL..."gokz-core.txt"

--- a/addons/sourcemod/scripting/gokz-errorboxfixer.sp
+++ b/addons/sourcemod/scripting/gokz-errorboxfixer.sp
@@ -15,7 +15,7 @@ public Plugin myinfo =
 	author = "1NutWunDeR",
 	description = "Adds missing models for KZ maps",
 	version = GOKZ_VERSION,
-	url = "https://bitbucket.org/kztimerglobalteam/gokz"
+	url = GOKZ_SOURCE_URL
 };
 
 #define UPDATER_URL GOKZ_UPDATER_BASE_URL..."gokz-errorboxfixer.txt"

--- a/addons/sourcemod/scripting/gokz-global.sp
+++ b/addons/sourcemod/scripting/gokz-global.sp
@@ -30,7 +30,7 @@ public Plugin myinfo =
 	author = "DanZay", 
 	description = "Provides centralised records and bans via GlobalAPI", 
 	version = GOKZ_VERSION, 
-	url = "https://bitbucket.org/kztimerglobalteam/gokz"
+	url = GOKZ_SOURCE_URL
 };
 
 #define UPDATER_URL GOKZ_UPDATER_BASE_URL..."gokz-global.txt"

--- a/addons/sourcemod/scripting/gokz-goto.sp
+++ b/addons/sourcemod/scripting/gokz-goto.sp
@@ -20,7 +20,7 @@ public Plugin myinfo =
 	author = "DanZay", 
 	description = "Allows players to teleport to another player", 
 	version = GOKZ_VERSION, 
-	url = "https://bitbucket.org/kztimerglobalteam/gokz"
+	url = GOKZ_SOURCE_URL
 };
 
 #define UPDATER_URL GOKZ_UPDATER_BASE_URL..."gokz-goto.txt"

--- a/addons/sourcemod/scripting/gokz-hud.sp
+++ b/addons/sourcemod/scripting/gokz-hud.sp
@@ -23,7 +23,7 @@ public Plugin myinfo =
 	author = "DanZay", 
 	description = "Provides HUD and UI features", 
 	version = GOKZ_VERSION, 
-	url = "https://bitbucket.org/kztimerglobalteam/gokz"
+	url = GOKZ_SOURCE_URL
 };
 
 #define UPDATER_URL GOKZ_UPDATER_BASE_URL..."gokz-hud.txt"

--- a/addons/sourcemod/scripting/gokz-jumpbeam.sp
+++ b/addons/sourcemod/scripting/gokz-jumpbeam.sp
@@ -22,7 +22,7 @@ public Plugin myinfo =
 	author = "DanZay", 
 	description = "Provides option to leave behind a trail when in midair", 
 	version = GOKZ_VERSION, 
-	url = "https://bitbucket.org/kztimerglobalteam/gokz"
+	url = GOKZ_SOURCE_URL
 };
 
 #define UPDATER_URL GOKZ_UPDATER_BASE_URL..."gokz-jumpbeam.txt"

--- a/addons/sourcemod/scripting/gokz-jumpstats.sp
+++ b/addons/sourcemod/scripting/gokz-jumpstats.sp
@@ -25,7 +25,7 @@ public Plugin myinfo =
 	author = "DanZay", 
 	description = "Tracks and outputs movement statistics", 
 	version = GOKZ_VERSION, 
-	url = "https://bitbucket.org/kztimerglobalteam/gokz"
+	url = GOKZ_SOURCE_URL
 };
 
 #define UPDATER_URL GOKZ_UPDATER_BASE_URL..."gokz-jumpstats.txt"

--- a/addons/sourcemod/scripting/gokz-localdb.sp
+++ b/addons/sourcemod/scripting/gokz-localdb.sp
@@ -21,7 +21,7 @@ public Plugin myinfo =
 	author = "DanZay", 
 	description = "Provides database for players, maps, courses and times", 
 	version = GOKZ_VERSION, 
-	url = "https://bitbucket.org/kztimerglobalteam/gokz"
+	url = GOKZ_SOURCE_URL
 };
 
 #define UPDATER_URL GOKZ_UPDATER_BASE_URL..."gokz-localdb.txt"

--- a/addons/sourcemod/scripting/gokz-localranks.sp
+++ b/addons/sourcemod/scripting/gokz-localranks.sp
@@ -27,7 +27,7 @@ public Plugin myinfo =
 	author = "DanZay", 
 	description = "Extends and provides in-game functionality for local database", 
 	version = GOKZ_VERSION, 
-	url = "https://bitbucket.org/kztimerglobalteam/gokz"
+	url = GOKZ_SOURCE_URL
 };
 
 #define UPDATER_URL GOKZ_UPDATER_BASE_URL..."gokz-localranks.txt"

--- a/addons/sourcemod/scripting/gokz-measure.sp
+++ b/addons/sourcemod/scripting/gokz-measure.sp
@@ -23,7 +23,7 @@ public Plugin myinfo =
 	author = "DanZay", 
 	description = "Provides tools for measuring things", 
 	version = GOKZ_VERSION, 
-	url = "https://bitbucket.org/kztimerglobalteam/gokz"
+	url = GOKZ_SOURCE_URL
 };
 
 #define UPDATER_URL GOKZ_UPDATER_BASE_URL..."gokz-measure.txt"

--- a/addons/sourcemod/scripting/gokz-mode-kztimer.sp
+++ b/addons/sourcemod/scripting/gokz-mode-kztimer.sp
@@ -24,7 +24,7 @@ public Plugin myinfo =
 	author = "DanZay", 
 	description = "KZTimer mode for GOKZ", 
 	version = GOKZ_VERSION, 
-	url = "https://bitbucket.org/kztimerglobalteam/gokz"
+	url = GOKZ_SOURCE_URL
 };
 
 #define UPDATER_URL GOKZ_UPDATER_BASE_URL..."gokz-mode-kztimer.txt"

--- a/addons/sourcemod/scripting/gokz-mode-simplekz.sp
+++ b/addons/sourcemod/scripting/gokz-mode-simplekz.sp
@@ -24,7 +24,7 @@ public Plugin myinfo =
 	author = "DanZay", 
 	description = "SimpleKZ mode for GOKZ", 
 	version = GOKZ_VERSION, 
-	url = "https://bitbucket.org/kztimerglobalteam/gokz"
+	url = GOKZ_SOURCE_URL
 };
 
 #define UPDATER_URL GOKZ_UPDATER_BASE_URL..."gokz-mode-simplekz.txt"

--- a/addons/sourcemod/scripting/gokz-mode-vanilla.sp
+++ b/addons/sourcemod/scripting/gokz-mode-vanilla.sp
@@ -24,7 +24,7 @@ public Plugin myinfo =
 	author = "DanZay", 
 	description = "Vanilla mode for GOKZ", 
 	version = GOKZ_VERSION, 
-	url = "https://bitbucket.org/kztimerglobalteam/gokz"
+	url = GOKZ_SOURCE_URL
 };
 
 #define UPDATER_URL GOKZ_UPDATER_BASE_URL..."gokz-mode-vanilla.txt"

--- a/addons/sourcemod/scripting/gokz-momsurffix.sp
+++ b/addons/sourcemod/scripting/gokz-momsurffix.sp
@@ -16,7 +16,7 @@ public Plugin myinfo = {
 	author = "GAMMA CASE",
 	description = "Ported surf fix from momentum mod. Modified for GOKZ by GameChaos. Original source code: https://github.com/GAMMACASE/MomSurfFix",
 	version = GOKZ_VERSION,
-	url = "https://bitbucket.org/kztimerglobalteam/gokz"
+	url = GOKZ_SOURCE_URL
 };
 
 #define FLT_EPSILON 1.192092896e-07

--- a/addons/sourcemod/scripting/gokz-paint.sp
+++ b/addons/sourcemod/scripting/gokz-paint.sp
@@ -21,7 +21,7 @@ public Plugin myinfo =
 	author = "zealain", 
 	description = "Provides client sided paint for visibility", 
 	version = GOKZ_VERSION, 
-	url = "https://bitbucket.org/kztimerglobalteam/gokz"
+	url = GOKZ_SOURCE_URL
 };
 
 #define UPDATER_URL GOKZ_UPDATER_BASE_URL..."gokz-paint.txt"

--- a/addons/sourcemod/scripting/gokz-pistol.sp
+++ b/addons/sourcemod/scripting/gokz-pistol.sp
@@ -21,7 +21,7 @@ public Plugin myinfo =
 	author = "DanZay", 
 	description = "Allows players to pick a pistol to KZ with", 
 	version = GOKZ_VERSION, 
-	url = "https://bitbucket.org/kztimerglobalteam/gokz"
+	url = GOKZ_SOURCE_URL
 };
 
 #define UPDATER_URL GOKZ_UPDATER_BASE_URL..."gokz-pistols.txt"

--- a/addons/sourcemod/scripting/gokz-playermodels.sp
+++ b/addons/sourcemod/scripting/gokz-playermodels.sp
@@ -22,7 +22,7 @@ public Plugin myinfo =
 	author = "DanZay", 
 	description = "Sets player's model upon spawning", 
 	version = GOKZ_VERSION, 
-	url = "https://bitbucket.org/kztimerglobalteam/gokz"
+	url = GOKZ_SOURCE_URL
 };
 
 #define UPDATER_URL GOKZ_UPDATER_BASE_URL..."gokz-playermodels.txt"

--- a/addons/sourcemod/scripting/gokz-profile.sp
+++ b/addons/sourcemod/scripting/gokz-profile.sp
@@ -22,7 +22,7 @@ public Plugin myinfo =
 	author = "zealain", 
 	description = "Player profiles and ranks based on local and global data.", 
 	version = GOKZ_VERSION, 
-	url = "https://bitbucket.org/kztimerglobalteam/gokz"
+	url = GOKZ_SOURCE_URL
 };
 
 #define UPDATER_URL GOKZ_UPDATER_BASE_URL..."gokz-profile.txt"

--- a/addons/sourcemod/scripting/gokz-quiet.sp
+++ b/addons/sourcemod/scripting/gokz-quiet.sp
@@ -21,7 +21,7 @@ public Plugin myinfo =
 	author = "DanZay", 
 	description = "Provides options for a quieter KZ experience", 
 	version = GOKZ_VERSION, 
-	url = "https://bitbucket.org/kztimerglobalteam/gokz"
+	url = GOKZ_SOURCE_URL
 };
 
 #define UPDATER_URL GOKZ_UPDATER_BASE_URL..."gokz-quiet.txt"

--- a/addons/sourcemod/scripting/gokz-racing.sp
+++ b/addons/sourcemod/scripting/gokz-racing.sp
@@ -18,7 +18,7 @@ public Plugin myinfo =
 	author = "DanZay", 
 	description = "Lets players race against each other", 
 	version = GOKZ_VERSION, 
-	url = "https://bitbucket.org/kztimerglobalteam/gokz"
+	url = GOKZ_SOURCE_URL
 };
 
 #define UPDATER_URL GOKZ_UPDATER_BASE_URL..."gokz-racing.txt"

--- a/addons/sourcemod/scripting/gokz-replays.sp
+++ b/addons/sourcemod/scripting/gokz-replays.sp
@@ -30,7 +30,7 @@ public Plugin myinfo =
 	author = "DanZay", 
 	description = "Records runs to disk and allows playback using bots", 
 	version = GOKZ_VERSION, 
-	url = "https://bitbucket.org/kztimerglobalteam/gokz"
+	url = GOKZ_SOURCE_URL
 };
 
 #define UPDATER_URL GOKZ_UPDATER_BASE_URL..."gokz-replays.txt"

--- a/addons/sourcemod/scripting/gokz-saveloc.sp
+++ b/addons/sourcemod/scripting/gokz-saveloc.sp
@@ -19,7 +19,7 @@ public Plugin myinfo =
 	author = "JWL", 
 	description = "Allows players to save/load locations that preserve position, angles, and velocity", 
 	version = GOKZ_VERSION, 
-	url = "https://bitbucket.org/kztimerglobalteam/gokz"
+	url = GOKZ_SOURCE_URL
 };
 
 #define UPDATER_URL GOKZ_UPDATER_BASE_URL..."gokz-saveloc.txt"

--- a/addons/sourcemod/scripting/gokz-slayonend.sp
+++ b/addons/sourcemod/scripting/gokz-slayonend.sp
@@ -18,7 +18,7 @@ public Plugin myinfo =
 	author = "DanZay", 
 	description = "Adds option to slay the player upon ending their timer", 
 	version = GOKZ_VERSION, 
-	url = "https://bitbucket.org/kztimerglobalteam/gokz"
+	url = GOKZ_SOURCE_URL
 };
 
 #define UPDATER_URL GOKZ_UPDATER_BASE_URL..."gokz-slayonend.txt"

--- a/addons/sourcemod/scripting/gokz-spec.sp
+++ b/addons/sourcemod/scripting/gokz-spec.sp
@@ -19,7 +19,7 @@ public Plugin myinfo =
 	author = "DanZay", 
 	description = "Provides easy ways to spectate players", 
 	version = GOKZ_VERSION, 
-	url = "https://bitbucket.org/kztimerglobalteam/gokz"
+	url = GOKZ_SOURCE_URL
 };
 
 #define UPDATER_URL GOKZ_UPDATER_BASE_URL..."gokz-spec.txt"

--- a/addons/sourcemod/scripting/gokz-tips.sp
+++ b/addons/sourcemod/scripting/gokz-tips.sp
@@ -22,7 +22,7 @@ public Plugin myinfo =
 	author = "DanZay", 
 	description = "Prints tips to chat periodically based on loaded plugins", 
 	version = GOKZ_VERSION, 
-	url = "https://bitbucket.org/kztimerglobalteam/gokz"
+	url = GOKZ_SOURCE_URL
 };
 
 #define UPDATER_URL GOKZ_UPDATER_BASE_URL..."gokz-tips.txt"

--- a/addons/sourcemod/scripting/include/gokz.inc
+++ b/addons/sourcemod/scripting/include/gokz.inc
@@ -32,6 +32,7 @@ enum ObsMode
 
 // =====[ CONSTANTS ]=====
 
+#define GOKZ_SOURCE_URL "https://github.com/KZGlobalTeam/gokz"
 #define GOKZ_UPDATER_BASE_URL "http://updater.gokz.org/v2/"
 #define GOKZ_COLLISION_GROUP_STANDARD 2
 #define GOKZ_COLLISION_GROUP_NOTRIGGER 1


### PR DESCRIPTION
Corrects plugin source urls to point to this GitHub repository instead of the old Bitbucket repository.
This creates a new `GOKZ_SOURCE_URL` constant in `gokz.inc` that should be used for future modules/plugins.