### PR TITLE
Reduce loadloc invalidation duration

### DIFF
--- a/addons/sourcemod/scripting/gokz-saveloc.sp
+++ b/addons/sourcemod/scripting/gokz-saveloc.sp
@@ -23,7 +23,7 @@ public Plugin myinfo =
 };
 
 #define UPDATER_URL GOKZ_UPDATER_BASE_URL..."gokz-saveloc.txt"
-#define LOADLOC_INVALIDATE_DURATION 1.0
+#define LOADLOC_INVALIDATE_DURATION 0.12
 #define MAX_LOCATION_NAME_LENGTH 32
 
 enum struct Location {


### PR DESCRIPTION
Current duration is way too long and makes some start timer techs no longer feasible or very awkward (eg. kz_scicret bonus on VNL where accelerating from 0 to 85 takes a lot of time, or kz_mz), this new duration should be closer to the duration used in `sm_start`.
