### PR TITLE
Refactor sm_updatemappool to use transactions

### DIFF
--- a/addons/sourcemod/scripting/gokz-localranks/db/sql.sp
+++ b/addons/sourcemod/scripting/gokz-localranks/db/sql.sp
@@ -17,16 +17,16 @@ ALTER TABLE Maps \
 char sqlite_maps_insertranked[] = "\
 INSERT OR IGNORE INTO Maps \
     (InRankedPool, Name) \
-    VALUES %s";
+    VALUES (%d, '%s')";
 
 char sqlite_maps_updateranked[] = "\
 UPDATE OR IGNORE Maps \
     SET InRankedPool=%d \
-    WHERE Name IN (%s)";
+    WHERE Name = '%s'";
 
 char mysql_maps_upsertranked[] = "\
 INSERT INTO Maps (InRankedPool, Name) \
-    VALUES %s \
+    VALUES (%d, '%s') \
     ON DUPLICATE KEY UPDATE \
     InRankedPool=VALUES(InRankedPool)";
 

--- a/addons/sourcemod/scripting/gokz-localranks/db/update_ranked_map_pool.sp
+++ b/addons/sourcemod/scripting/gokz-localranks/db/update_ranked_map_pool.sp
@@ -30,7 +30,7 @@ void DB_UpdateRankedMapPool(int client)
 		return;
 	}
 
-	char map[33];
+	char map[256];
 	int mapsCount = 0;
 
 	Transaction txn = new Transaction();
@@ -56,10 +56,10 @@ void DB_UpdateRankedMapPool(int client)
 		{
 			case DatabaseType_SQLite:
 			{
-				char updateQuery[256];
+				char updateQuery[512];
 				gH_DB.Format(updateQuery, sizeof(updateQuery), sqlite_maps_updateranked, 1, map);
 
-				char insertQuery[256];
+				char insertQuery[512];
 				gH_DB.Format(insertQuery, sizeof(insertQuery), sqlite_maps_insertranked, 1, map);
 
 				txn.AddQuery(updateQuery);
@@ -67,7 +67,7 @@ void DB_UpdateRankedMapPool(int client)
 			}
 			case DatabaseType_MySQL:
 			{
-				char query[256];
+				char query[512];
 				gH_DB.Format(query, sizeof(query), mysql_maps_upsertranked, 1, map);
 
 				txn.AddQuery(query);

--- a/addons/sourcemod/scripting/gokz-localranks/db/update_ranked_map_pool.sp
+++ b/addons/sourcemod/scripting/gokz-localranks/db/update_ranked_map_pool.sp
@@ -10,11 +10,10 @@ void DB_UpdateRankedMapPool(int client)
 	File file = OpenFile(LR_CFG_MAP_POOL, "r");
 	if (file == null)
 	{
-		LogError("Failed to load file: \"%s\".", LR_CFG_MAP_POOL);
+		LogError("Failed to load file: '%s'.", LR_CFG_MAP_POOL);
 		if (IsValidClient(client))
 		{
-			// TODO Translation phrases?
-			GOKZ_PrintToChat(client, true, "{grey}There was a problem opening file '%s'.", LR_CFG_MAP_POOL);
+			GOKZ_PrintToChat(client, true, "%t", "Ranked Map Pool - Error");
 		}
 		return;
 	}
@@ -68,10 +67,11 @@ void DB_UpdateRankedMapPool(int client)
 
 	if (mapsCount == 0)
 	{
-		GOKZ_PrintToChatAndLog(client, true, "{darkred}No maps found in file '%s'.", LR_CFG_MAP_POOL);
+		LogError("No maps found in file: '%s'.", LR_CFG_MAP_POOL);
 
 		if (IsValidClient(client))
 		{
+			GOKZ_PrintToChat(client, true, "%t", "Ranked Map Pool - No Maps In File");
 			GOKZ_PlayErrorSound(client);
 		}
 
@@ -95,8 +95,7 @@ public void DB_TxnSuccess_UpdateRankedMapPool(Handle db, int userid, int numQuer
 	if (IsValidClient(client))
 	{
 		LogMessage("The ranked map pool was updated by %L.", client);
-		// TODO Translation phrases?
-		GOKZ_PrintToChat(client, true, "{grey}The ranked map pool was updated.");
+		GOKZ_PrintToChat(client, true, "%t", "Ranked Map Pool - Success");
 	}
 	else
 	{

--- a/addons/sourcemod/scripting/gokz-localranks/db/update_ranked_map_pool.sp
+++ b/addons/sourcemod/scripting/gokz-localranks/db/update_ranked_map_pool.sp
@@ -7,17 +7,6 @@
 
 void DB_UpdateRankedMapPool(int client)
 {
-	if (g_DBType != DatabaseType_SQLite && g_DBType != DatabaseType_MySQL)
-	{
-		LogError("Unsupported database type, cannot update map pool");
-		if (IsValidClient(client))
-		{
-			// TODO Translation phrases?
-			GOKZ_PrintToChat(client, true, "{grey}There was a problem updating the map pool.", LR_CFG_MAP_POOL);
-		}
-		return;
-	}
-
 	File file = OpenFile(LR_CFG_MAP_POOL, "r");
 	if (file == null)
 	{

--- a/addons/sourcemod/translations/gokz-localranks.phrases.txt
+++ b/addons/sourcemod/translations/gokz-localranks.phrases.txt
@@ -51,6 +51,18 @@
 		"chi"		"{grey}本服务器没有设定可排名的地图."
 		"ru"		"{grey}На этом сервере нет ранжирования по картам."
 	}
+	"Ranked Map Pool - Error"
+	{
+		"en"		"{darkred}There was a problem updating the ranked map pool."
+	}
+	"Ranked Map Pool - Success"
+	{
+		"en"		"{grey}The ranked map pool was updated."
+	}
+        "Ranked Map Pool - No Maps In File"
+	{
+		"en"		"{darkred}No maps found in the ranked map pool file."
+	}
 	"New Record (NUB)"
 	{
 		// Bill set a new NUB RECORD [Mode]

--- a/cfg/sourcemod/gokz/gokz-localranks-mappool.cfg
+++ b/cfg/sourcemod/gokz/gokz-localranks-mappool.cfg
@@ -1,4 +1,5 @@
 // Map list read by the gokz-localranks !updatemappool command
+// The maximum supported length for a single line is 255 characters
 
 // You can comment like this
 ; or you can comment like this


### PR DESCRIPTION
Refactors `sm_updatemappool` to use transactions for the map queries.
This will fix #391, which has been popping up often lately, as the map list has grown to the point where SM runs out of heap.

This has been tested locally on SQLite (SM 1.11.0.6911) and MySQL 5.7.35.

### Raised buffer size for a line

This PR also raises the buffer size of a line being read to get around `fgets` weirdness, which `File.ReadLine` uses.
If the line exceeds the old 32 character limit, the very next `File.ReadLine` will now contain the rest of the previous line.

> The C library function char *fgets(char *str, int n, FILE *stream) reads a line from the specified stream and stores it into the string pointed to by str. **It stops when either (n-1) characters are read**, the newline character is read, or the end-of-file is reached, whichever comes first.

The new limit is set to 255 characters, which should be a very reasonable limit.
It is now also documented in the default `cfg/sourcemod/gokz/gokz-localranks-mappool.cfg` file.

<details>
  <summary>Example of this behaviour</summary>

Consider a comment line that is over 32 characters: `; this is a very long comment that is over 32 chars`.
1. The first `File.ReadLine` call will return `; this is a very long comment th`.
2. The very next `File.ReadLine` will now return the rest of the previous line: `at is over 32 chars`.
    - This is unexpected, as `at is over 32 chars` will now be considered a map name and not a comment.
</details>