### PR TITLE
Only enable global plugin on VAC secured servers

### DIFF
--- a/addons/sourcemod/scripting/gokz-global.sp
+++ b/addons/sourcemod/scripting/gokz-global.sp
@@ -2,6 +2,7 @@
 
 #include <sdktools>
 
+#include <SteamWorks>
 #include <GlobalAPI>
 #include <gokz/anticheat>
 #include <gokz/core>
@@ -83,7 +84,10 @@ public void OnPluginStart()
 	{
 		SetFailState("gokz-global currently only supports 128 tickrate servers.");
 	}
-	
+	if (!SteamWorks_IsVACEnabled())
+	{
+		SetFailState("gokz-global currently only supports VAC-secured servers.");
+	}
 	LoadTranslations("gokz-common.phrases");
 	LoadTranslations("gokz-global.phrases");
 	

--- a/addons/sourcemod/scripting/include/SteamWorks.inc
+++ b/addons/sourcemod/scripting/include/SteamWorks.inc
@@ -270,9 +270,9 @@ typeset SteamWorksHTTPDataReceived
 
 typeset SteamWorksHTTPBodyCallback
 {
-	function void (const char sData[]);
-	function void (const char sData[], any value);
-	function void (const int data[], any value, int datalen);
+	function void (const char[] sData);
+	function void (const char[] sData, any value);
+	function void (const int[] data, any value, int datalen);
 };
 
 #else


### PR DESCRIPTION
Apparently that wasn't the case before... 