### PR TITLE
Move clantag block to gokz-profile

### DIFF
--- a/addons/sourcemod/scripting/gokz-core.sp
+++ b/addons/sourcemod/scripting/gokz-core.sp
@@ -200,17 +200,6 @@ public void OnPlayerRunCmdPost(int client, int buttons, int impulse, const float
 	UpdateTrackingVariables(client, cmdnum, buttons); // This should be last
 }
 
-public Action OnClientCommandKeyValues(int client, KeyValues kv)
-{
-	// Block clan tag changes - Credit: GoD-Tony (https://forums.alliedmods.net/showpost.php?p=2337679&postcount=6)
-	char cmd[16];
-	if (kv.GetSectionName(cmd, sizeof(cmd)) && StrEqual(cmd, "ClanTagChanged", false))
-	{
-		return Plugin_Handled;
-	}
-	return Plugin_Continue;
-}
-
 public void OnClientCookiesCached(int client)
 {
 	OnClientCookiesCached_Options(client);

--- a/addons/sourcemod/scripting/gokz-profile.sp
+++ b/addons/sourcemod/scripting/gokz-profile.sp
@@ -97,6 +97,17 @@ public void OnLibraryRemoved(const char[] name)
 
 // =====[ EVENTS ]=====
 
+public Action OnClientCommandKeyValues(int client, KeyValues kv)
+{
+	// Block clan tag changes - Credit: GoD-Tony (https://forums.alliedmods.net/showpost.php?p=2337679&postcount=6)
+	char cmd[16];
+	if (kv.GetSectionName(cmd, sizeof(cmd)) && StrEqual(cmd, "ClanTagChanged", false))
+	{
+		return Plugin_Handled;
+	}
+	return Plugin_Continue;
+}
+
 public void OnRebuildAdminCache(AdminCachePart part)
 {
 	for (int client = 1; client <= MaxClients; client++)


### PR DESCRIPTION
Clan tag change block should belong in the plugin that modify clan tags. Some server owners want to enable player clan tags and disable the profile plugin.
