### PR TITLE
Allow player to spectate other players with timer on while in spectate

### DIFF
--- a/addons/sourcemod/scripting/gokz-spec.sp
+++ b/addons/sourcemod/scripting/gokz-spec.sp
@@ -126,7 +126,7 @@ bool SpectatePlayer(int client, int target, bool printMessage = true)
 
 bool CanSpectate(int client)
 {
-	return GOKZ_GetPaused(client) || GOKZ_GetCanPause(client);
+	return !IsPlayerAlive(client) || GOKZ_GetPaused(client) || GOKZ_GetCanPause(client);
 }
 
 public int MenuHandler_Spec(Menu menu, MenuAction action, int param1, int param2)


### PR DESCRIPTION
Previously if you are spectating someone, but your timer is on, and the spectated player is in mid-air, you cannot spectate other players. 
