### PR TITLE
Reset globally verified status on player join

### DIFF
--- a/addons/sourcemod/scripting/gokz-global.sp
+++ b/addons/sourcemod/scripting/gokz-global.sp
@@ -243,6 +243,7 @@ Action FPSKickPlayer(Handle timer, int userid)
 
 public void OnClientPutInServer(int client)
 {
+	gB_GloballyVerified[client] = false;
 	gB_waitingForFPSKick[client] = false;
 	OnClientPutInServer_PrintRecords(client);
 }


### PR DESCRIPTION
This fixes an issues that might happen in the following scenario:
1. Unbanned player joins.
2. Unbanned player leaves.
3. Global API goes offline.
4. A Banned player joins, and gets the same client id as the unbanned player had. This causes him to be seen as Unbanned.
5. The Banned player plays, etc.
6. API goes up, and requests are now being sent to the Global API as a part of the retry proccess, causing multiple bans etc. to appear.

To prevent this, we reset the status of a client to not be Globally verified when joining the server, so that we always start from a clean state when the Global Ban check is done in OnClientPostAdminCheck.
