### PR TITLE
Fix potential sound hook crash and add valid client check to weapon sound to prevent errors

### DIFF
--- a/addons/sourcemod/scripting/gokz-quiet.sp
+++ b/addons/sourcemod/scripting/gokz-quiet.sp
@@ -179,6 +179,10 @@ public Action Hook_WeaponSound(UserMsg msg_id, Protobuf msg, const int[] players
 	for (int i = 0; i < playersNum; i++)
 	{
 		int client = players[i];
+		if (!IsValidClient(client))
+		{
+			continue;
+		}
 		if (GOKZ_GetOption(client, gC_QTOptionNames[QTOption_ShowPlayers]) == ShowPlayers_Enabled
 			|| entidx == client
 			|| entidx == GetObserverTarget(client))
@@ -235,14 +239,14 @@ public void RequestFrame_WeaponSound(DataPack dp)
 
 	Protobuf newMsg = view_as<Protobuf>(StartMessageEx(msg_id, newClients, newTotal, flags));
 
-	newMsg.AddInt("entidx", dp.ReadCell());
-	newMsg.AddFloat("origin_x", dp.ReadFloat());
-	newMsg.AddFloat("origin_y", dp.ReadFloat());
-	newMsg.AddFloat("origin_z", dp.ReadFloat());
+	newMsg.SetInt("entidx", dp.ReadCell());
+	newMsg.SetFloat("origin_x", dp.ReadFloat());
+	newMsg.SetFloat("origin_y", dp.ReadFloat());
+	newMsg.SetFloat("origin_z", dp.ReadFloat());
 	char path[PLATFORM_MAX_PATH];
 	dp.ReadString(path, sizeof(path));
-	newMsg.AddString("sound", path);
-	newMsg.AddFloat("timestamp", dp.ReadFloat());
+	newMsg.SetString("sound", path);
+	newMsg.SetFloat("timestamp", dp.ReadFloat());
 
 	EndMessage();
 


### PR DESCRIPTION
During the weapon sound hook the list of clients can contain invalid clients somehow.

Also fix the sound hook using the wrong functions to set variables.