### PR TITLE
Hotfix for VAC check

### DIFF
--- a/addons/sourcemod/scripting/gokz-global.sp
+++ b/addons/sourcemod/scripting/gokz-global.sp
@@ -2,7 +2,6 @@
 
 #include <sdktools>
 
-#include <SteamWorks>
 #include <GlobalAPI>
 #include <gokz/anticheat>
 #include <gokz/core>
@@ -84,7 +83,7 @@ public void OnPluginStart()
 	{
 		SetFailState("gokz-global currently only supports 128 tickrate servers.");
 	}
-	if (!SteamWorks_IsVACEnabled())
+	if (FindCommandLineParam("-insecure") || FindCommandLineParam("-tools"))
 	{
 		SetFailState("gokz-global currently only supports VAC-secured servers.");
 	}


### PR DESCRIPTION
`SteamWorks_IsVACEnabled` can be called before SteamWorks is actually ready, leading into VAC check failing. Also this might not work if you launch the server while steam is down, which is... not good.

This one checks for the launch options that disables VAC instead.