### PR TITLE
Fix going to custom start not stopping timer

### DIFF
--- a/addons/sourcemod/scripting/gokz-core/timer/timer.sp
+++ b/addons/sourcemod/scripting/gokz-core/timer/timer.sp
@@ -60,7 +60,7 @@ bool TimerStart(int client, int course, bool allowMidair = false, bool playSound
 		 || !IsPlayerValidMoveType(client)
 		 || !allowMidair && (!Movement_GetOnGround(client) || JustLanded(client))
 		 || allowMidair && !Movement_GetOnGround(client) && (!GOKZ_GetValidJump(client) || GOKZ_GetHitPerf(client))
-		 || (GOKZ_GetTimerRunning(client) && GOKZ_GetCourse(client) != course))
+		 || (GOKZ_GetTimerRunning(client) && GOKZ_GetCourse(client) != course && GetVirtualStartCourse(client) != course))
 	{
 		return false;
 	}

--- a/addons/sourcemod/scripting/gokz-core/timer/virtual_buttons.sp
+++ b/addons/sourcemod/scripting/gokz-core/timer/virtual_buttons.sp
@@ -37,7 +37,7 @@ bool GetHasVirtualEndButton(int client)
 	return hasVirtualEndButton[client];
 }
 
-bool GetVirtualStartCourse(int client)
+int GetVirtualStartCourse(int client)
 {
 	return virtualStartCourse[client];
 }

--- a/addons/sourcemod/scripting/gokz-core/timer/virtual_buttons.sp
+++ b/addons/sourcemod/scripting/gokz-core/timer/virtual_buttons.sp
@@ -37,6 +37,11 @@ bool GetHasVirtualEndButton(int client)
 	return hasVirtualEndButton[client];
 }
 
+bool GetVirtualStartCourse(int client)
+{
+	return virtualStartCourse[client];
+}
+
 bool ToggleVirtualButtonsLock(int client)
 {
 	virtualButtonsLocked[client] = !virtualButtonsLocked[client];


### PR DESCRIPTION
If you `!ssp` and setup timer tech for a button course, then start a course using zones, then do `!start`, the timer for the zone course does not get stopped. Caused by #346.