### PR TITLE
Fix HUD text display taking over other plugins' display

### DIFF
--- a/addons/sourcemod/scripting/gokz-hud/racing_text.sp
+++ b/addons/sourcemod/scripting/gokz-hud/racing_text.sp
@@ -123,7 +123,7 @@ static void ShowCountdownText(KZPlayer player, KZPlayer targetPlayer)
 	int colour[4];
 	GetCountdownColour(timeToStart, colour);
 
-	SetHudTextParams(-1.0, 0.3, 1.0, colour[0], colour[1], colour[2], colour[3], 0, 1.0, 0.0, 0.0);
+	SetHudTextParams(-1.0, 0.3, GetTextHoldTime(gB_FastUpdateRate[player.ID] ? 3 : 6), colour[0], colour[1], colour[2], colour[3], 0, 1.0, 0.0, 0.0);
 	ShowSyncHudText(player.ID, racingHudSynchronizer, "%t\n\n%d", "Get Ready", IntMax(RoundToCeil(timeToStart), 1));
 }
 
@@ -162,6 +162,6 @@ static void ShowStartedText(KZPlayer player, KZPlayer targetPlayer)
 		return;
 	}
 
-	SetHudTextParams(-1.0, 0.3, 1.0, 0, 255, 0, 255, 0, 1.0, 0.0, 0.0);
+	SetHudTextParams(-1.0, 0.3, GetTextHoldTime(gB_FastUpdateRate[player.ID] ? 3 : 6), 0, 255, 0, 255, 0, 1.0, 0.0, 0.0);
 	ShowSyncHudText(player.ID, racingHudSynchronizer, "%t", "Go!");
 } 

--- a/addons/sourcemod/scripting/gokz-hud/speed_text.sp
+++ b/addons/sourcemod/scripting/gokz-hud/speed_text.sp
@@ -98,11 +98,11 @@ static void ShowSpeedText(KZPlayer player, HUDInfo info)
 			// Set params based on the available screen space at max scaling HUD
 			if (!IsDrawingInfoPanel(player.ID))
 			{
-				SetHudTextParams(-1.0, 0.75, 1.0, colour[0], colour[1], colour[2], colour[3], 0, 1.0, 0.0, 0.0);
+				SetHudTextParams(-1.0, 0.75, GetTextHoldTime(gB_FastUpdateRate[player.ID] ? 3 : 6), colour[0], colour[1], colour[2], colour[3], 0, 1.0, 0.0, 0.0);
 			}
 			else
 			{
-				SetHudTextParams(-1.0, 0.65, 1.0, colour[0], colour[1], colour[2], colour[3], 0, 1.0, 0.0, 0.0);
+				SetHudTextParams(-1.0, 0.65, GetTextHoldTime(gB_FastUpdateRate[player.ID] ? 3 : 6), colour[0], colour[1], colour[2], colour[3], 0, 1.0, 0.0, 0.0);
 			}
 		}
 	}

--- a/addons/sourcemod/scripting/gokz-hud/timer_text.sp
+++ b/addons/sourcemod/scripting/gokz-hud/timer_text.sp
@@ -154,11 +154,11 @@ static void ShowTimerText(KZPlayer player, HUDInfo info)
 		{
 			case TimerText_Top:
 			{
-				SetHudTextParams(-1.0, 0.07, 1.0, colour[0], colour[1], colour[2], colour[3], 0, 1.0, 0.0, 0.0);
+				SetHudTextParams(-1.0, 0.07, GetTextHoldTime(gB_FastUpdateRate[player.ID] ? 3 : 6), colour[0], colour[1], colour[2], colour[3], 0, 1.0, 0.0, 0.0);
 			}
 			case TimerText_Bottom:
 			{
-				SetHudTextParams(-1.0, 0.9, 1.0, colour[0], colour[1], colour[2], colour[3], 0, 1.0, 0.0, 0.0);
+				SetHudTextParams(-1.0, 0.9, GetTextHoldTime(gB_FastUpdateRate[player.ID] ? 3 : 6), colour[0], colour[1], colour[2], colour[3], 0, 1.0, 0.0, 0.0);
 			}
 		}
 		

--- a/addons/sourcemod/scripting/include/gokz.inc
+++ b/addons/sourcemod/scripting/include/gokz.inc
@@ -1029,5 +1029,5 @@ stock int GOKZGetClientFromGameMovementAddress(Address addr, int offsetCGameMove
  */
 stock float GetTextHoldTime(int interval)
 {
-    return 2.5 * interval * GetTickInterval();
+    return 3 * interval * GetTickInterval();
 }

--- a/addons/sourcemod/scripting/include/gokz.inc
+++ b/addons/sourcemod/scripting/include/gokz.inc
@@ -1015,3 +1015,19 @@ stock int GOKZGetClientFromGameMovementAddress(Address addr, int offsetCGameMove
 	Address playerAddr = view_as<Address>(LoadFromAddress(view_as<Address>(view_as<int>(addr) + offsetCGameMovement_player), NumberType_Int32));
 	return GOKZGetEntityFromAddress(playerAddr);
 }
+
+/**
+ * Gets the ideal amount of time the text should be held for HUD messages.
+ * 
+ * The message buffer is only 16 slots long, and it is shared between 6 channels maximum.
+ * Assuming a message is sent every game frame, each channel used should be only taking around 2.5 slots on average.
+ * This also assumes all channels are used equally (so no other plugin taking all the channel buffer for itself).
+ * We want to use as much of the message buffer as possible to take into account latency variances.
+ * 
+ * @param interval						HUD message update interval, in tick intervals.
+ * @return								How long the text should be held for.
+ */
+stock float GetTextHoldTime(int interval)
+{
+    return 2.5 * interval * GetTickInterval();
+}


### PR DESCRIPTION
Related to #419, but does not really fix it because MHUD is still at fault.

The reuse logic with 6 channels is fine, and is not why the HUD text was unable to be displayed.
The cause is the client's internal message buffer which is 16 slots long and shared between 6 channels at once. The message in the buffer will only clear once the hold time is over. So a plugin sending one HUD message lasting for 0.5 seconds will immediately fill the buffer (that's 64 messages, which is way past 16), leaving no place for other plugins. 

The reason joining team or sending `round_start` event temporarily fixes the issue is because they trigger the message buffer wipe, but they come with other unwanted side effects. 

[Reference](https://github.com/perilouswithadollarsign/cstrike15_src/blob/f82112a2388b841d72cb62ca48ab1846dfcc11c8/game/client/message.cpp#L603-L619)