### PR TITLE
Make info panel text non reliable to increase update speed on high ping scenarios

### DIFF
--- a/addons/sourcemod/scripting/gokz-hud/info_panel.sp
+++ b/addons/sourcemod/scripting/gokz-hud/info_panel.sp
@@ -27,7 +27,7 @@ bool IsDrawingInfoPanel(int client)
 
 void OnPlayerRunCmdPost_InfoPanel(int client, int cmdnum, HUDInfo info)
 {
-	int updateSpeed = gB_FastUpdateRate[client] ? 3 : 6;
+	int updateSpeed = gB_FastUpdateRate[client] ? 1 : 10;
 	if (cmdnum % updateSpeed == 0 || info.IsTakeoff)
 	{
 		UpdateInfoPanel(client, info);

--- a/addons/sourcemod/scripting/gokz-hud/info_panel.sp
+++ b/addons/sourcemod/scripting/gokz-hud/info_panel.sp
@@ -27,14 +27,7 @@ bool IsDrawingInfoPanel(int client)
 
 void OnPlayerRunCmdPost_InfoPanel(int client, int cmdnum, HUDInfo info)
 {
-	int updateSpeed = 10;
-	if (gB_FastUpdateRate[client])
-	{
-		// The hint text panel update speed depends on the client ping.
-		// To optimize resource usage, we scale the update speed with it.
-		// The fastest speed the client can get is around once every 2 ticks.
-		updateSpeed = IntMax(1, RoundToFloor(GetClientAvgLatency(client, NetFlow_Outgoing) / GetTickInterval()));
-	}
+	int updateSpeed = gB_FastUpdateRate[client] ? 3 : 6;
 	if (cmdnum % updateSpeed == 0 || info.IsTakeoff)
 	{
 		UpdateInfoPanel(client, info);
@@ -273,7 +266,7 @@ void PrintCSGOHUDText(int client, const char[] format)
 
 	buff[sizeof(buff) - 1] = '\0';
 
-	Protobuf pb = view_as<Protobuf>(StartMessageOne("TextMsg", client, USERMSG_RELIABLE | USERMSG_BLOCKHOOKS));
+	Protobuf pb = view_as<Protobuf>(StartMessageOne("TextMsg", client, USERMSG_BLOCKHOOKS));
 	pb.SetInt("msg_dst", 4);
 	pb.AddString("params", "#SFUI_ContractKillStart");
 	pb.AddString("params", buff);


### PR DESCRIPTION
This is pretty huge. Previously the hint text panel update speed depends on the client ping, this is because the message is sent in a reliable channel. This means it will update really slowly if the client latency is significant. Besides, for something that updates as often as the info panel, that is not necessary. This change will finally make the info panel usable on high ping situations.
