### PR TITLE
Fix triggerfix infinitely looping on triggers using OnTrigger

### DIFF
--- a/addons/sourcemod/scripting/gokz-core.sp
+++ b/addons/sourcemod/scripting/gokz-core.sp
@@ -182,6 +182,7 @@ public Action OnPlayerRunCmd(int client, int &buttons, int &impulse, float vel[3
 {
 	gI_CmdNum[client] = cmdnum;
 	gI_TickCount[client] = tickcount;
+	OnPlayerRunCmd_Triggerfix(client);
 	OnPlayerRunCmd_MapTriggers(client, buttons);
 	OnPlayerRunCmd_Turnbinds(client, buttons, tickcount, angles);
 	return Plugin_Continue;

--- a/addons/sourcemod/scripting/gokz-core/triggerfix.sp
+++ b/addons/sourcemod/scripting/gokz-core/triggerfix.sp
@@ -207,6 +207,17 @@ public void OnGameFrame_Triggerfix()
 	}
 }
 
+void OnPlayerRunCmd_Triggerfix(int client)
+{
+	// Reset the Touch tracking. 
+	// While this is mostly unnecessary, it can also happen that the server runs multiple ticks of player movement at once, 
+	// therefore the triggers need to be checked again.
+	for (int trigger = 0; trigger < sizeof(triggerTouchFired[]); trigger++)
+	{
+		triggerTouchFired[client][trigger] = 0;
+	}
+}
+
 static void Event_PlayerJump(Event event, const char[] name, bool dontBroadcast)
 {
 	int client = GetClientOfUserId(event.GetInt("userid"));

--- a/addons/sourcemod/scripting/gokz-core/triggerfix.sp
+++ b/addons/sourcemod/scripting/gokz-core/triggerfix.sp
@@ -12,7 +12,7 @@ static int processMovementTicks[MAXPLAYERS+1];
 static float playerFrameTime[MAXPLAYERS+1];
 
 static bool touchingTrigger[MAXPLAYERS+1][2048];
-static bool triggerTouchFired[MAXPLAYERS+1][2048];
+static int triggerTouchFired[MAXPLAYERS+1][2048];
 static int lastGroundEnt[MAXPLAYERS + 1];
 static bool duckedLastTick[MAXPLAYERS + 1];
 static bool mapTeleportedSequentialTicks[MAXPLAYERS+1];
@@ -171,7 +171,7 @@ public void OnClientConnected_Triggerfix(int client)
 	for (int i = 0; i < sizeof(touchingTrigger[]); i++)
 	{
 		touchingTrigger[client][i] = false;
-		triggerTouchFired[client][i] = false;
+		triggerTouchFired[client][i] = 0;
 	}
 }
 
@@ -201,7 +201,7 @@ public void OnGameFrame_Triggerfix()
 			// so this should not be a big problem.
 			for (int trigger = 0; trigger < sizeof(triggerTouchFired[]); trigger++)
 			{
-				triggerTouchFired[client][trigger] = false;
+				triggerTouchFired[client][trigger] = 0;
 			}
 		}
 	}
@@ -246,7 +246,7 @@ static Action Hook_TriggerTouch(int entity, int other)
 {
 	if (1 <= other <= MaxClients)
 	{
-	 	triggerTouchFired[other][entity] = true;
+	 	triggerTouchFired[other][entity]++;
 	}
 	return Plugin_Continue;	
 }
@@ -335,13 +335,14 @@ static bool DoTriggerFix(int client, bool filterFix = false)
 			// Completely ignore push triggers.
 			continue;
 		}
-		if (filterFix && SDKCall(passesTriggerFilters, trigger, client))
+		if (filterFix && SDKCall(passesTriggerFilters, trigger, client) && triggerTouchFired[client][trigger] < GOKZ_MAX_RETOUCH_TRIGGER_COUNT)
 		{
 			// MarkEntitiesAsTouching always fires the Touch function even if it was already fired this tick.
 			SDKCall(markEntitiesAsTouching, serverGameEnts, client, trigger);
 			
 			// Player properties might be changed right after this so it will need to be triggered again.
-			triggerTouchFired[client][trigger] = false;
+			// Triggers changing this filter will loop onto itself infintely so we need to avoid that.
+			triggerTouchFired[client][trigger]++;
 			didSomething = true;
 		}
 		else if (!triggerTouchFired[client][trigger])
@@ -349,6 +350,7 @@ static bool DoTriggerFix(int client, bool filterFix = false)
 			// If the player is still touching the trigger on this tick, and Touch was not called for whatever reason
 			// in the last tick, we make sure that it is called now.
 			SDKCall(markEntitiesAsTouching, serverGameEnts, client, trigger);
+			triggerTouchFired[client][trigger]++;
 			didSomething = true;
 		}
 	}

--- a/addons/sourcemod/scripting/include/gokz/core.inc
+++ b/addons/sourcemod/scripting/include/gokz/core.inc
@@ -285,6 +285,9 @@ enum TriggerType
 #define GOKZ_SAFEGUARD_RESTART_MIN_DELAY 0.6
 #define GOKZ_SAFEGUARD_RESTART_MAX_DELAY 5.0
 
+// Prevents the player from retouching a trigger too often.
+#define GOKZ_MAX_RETOUCH_TRIGGER_COUNT 4
+
 stock char gC_TimeTypeNames[TIMETYPE_COUNT][] = 
 {
 	"NUB", 


### PR DESCRIPTION
Hotfix for side effect caused by #455.

Before the triggerfix code just doesn't work at all, probably. Fixes kz_noobfort and similar map with a filter setting trigger using `OnTrigger` freezing on the first jump.

This might actually finally patch some trigger cancelling shenanigans that were still around, to be tested. (Doesn't seem like it though)