### PR TITLE
Fix tpanglefix crashing servers on linux

### DIFF
--- a/addons/sourcemod/gamedata/gokz-tpanglefix.games.txt
+++ b/addons/sourcemod/gamedata/gokz-tpanglefix.games.txt
@@ -32,7 +32,7 @@
 			"WriteViewAngleUpdateReliableOffset"
 			{
 				"windows"	"363"
-				"linux"		"290"
+				"linux"		"294"
 			}
 			"ClientIndexOffset"
 			{

--- a/addons/sourcemod/scripting/gokz-tpanglefix.sp
+++ b/addons/sourcemod/scripting/gokz-tpanglefix.sp
@@ -96,12 +96,23 @@ void HookEvents()
 	}
 	// Prevent the server from crashing.
 	FindConVar("sv_parallel_sendsnapshot").SetBool(false);
+	FindConVar("sv_parallel_sendsnapshot").AddChangeHook(OnParallelSendSnapshotCvarChanged);
+
 	gI_ClientOffset = gamedataConf.GetOffset("ClientIndexOffset");
 	if (gI_ClientOffset == -1)
 	{
 		SetFailState("Failed to get ClientIndexOffset offset.");
 	}
 }
+
+void OnParallelSendSnapshotCvarChanged(ConVar convar, const char[] oldValue, const char[] newValue)
+{
+	if (convar.BoolValue)
+	{
+		convar.BoolValue = false;
+	}
+}
+
 public MRESReturn DHooks_OnWriteViewAngleUpdate_Pre(Address pThis)
 {
 	int client = LoadFromAddress(pThis + view_as<Address>(gI_ClientOffset), NumberType_Int32);


### PR DESCRIPTION
Fix gamedata (hopefully) and make sure the parallel snapshot cvar is off.

Fix to #472.