### PR TITLE
Only track jump during movement processing

### DIFF
--- a/addons/sourcemod/scripting/gokz-jumpstats.sp
+++ b/addons/sourcemod/scripting/gokz-jumpstats.sp
@@ -112,9 +112,10 @@ public Action OnPlayerRunCmd(int client, int &buttons, int &impulse, float vel[3
 	return Plugin_Continue;
 }
 
-public void OnPlayerRunCmdPost(int client, int buttons, int impulse, const float vel[3], const float angles[3], int weapon, int subtype, int cmdnum, int tickcount, int seed, const int mouse[2])
+public Action Movement_OnPlayerMovePost(int client)
 {
-	OnPlayerRunCmdPost_JumpTracking(client);
+	Movement_OnPlayerMovePost_JumpTracking(client);
+	return Plugin_Continue;
 }
 
 public void Movement_OnStartTouchGround(int client)

--- a/addons/sourcemod/scripting/gokz-jumpstats/jump_tracking.sp
+++ b/addons/sourcemod/scripting/gokz-jumpstats/jump_tracking.sp
@@ -1425,19 +1425,15 @@ public Action Movement_OnWalkMovePost(int client)
 	return Plugin_Continue;
 }
 
-public Action Movement_OnPlayerMovePost(int client)
-{
-	lastMovementProcessedTime[client] = jumpTrackers[client].tickCount;
-	return Plugin_Continue;
-}
 
-public void OnPlayerRunCmdPost_JumpTracking(int client)
+public void Movement_OnPlayerMovePost_JumpTracking(int client)
 {
 	if (!IsValidClient(client) || !IsPlayerAlive(client))
 	{
 		return;
 	}
 	
+	lastMovementProcessedTime[client] = jumpTrackers[client].tickCount;
 	// Check for always failstats
 	if (doFailstatAlways[client])
 	{


### PR DESCRIPTION
Fix a rare bug where your jump gets invalidated if the client/server gets a performance spike and spews broken jsalways stats like this:

```
zer0.k jumped 231.2947 units with a Multi Bunnyhop
KZT | 6 Strafes | 71% Sync | 243.86 Pre | 294.15 Max | 2 OL | 16 DA | 21.1° Width | 55.8 Height | 96 Airtime | 0.0 Offset | 0 Crouched
  #.  Sync      Gain      Loss      Airtime   Width     OL     DA     
  1.   88%       6.97      0.00       9%       12.0°     0      1
  2.   70%      10.78      0.74      20%       26.8°     2      2
  3.   75%      281.33     270.51      20%       25.4°     0      3
  4.   80%      12.18      0.00      20%       28.6°     0      2
  5.   73%      10.27      0.00      19%       25.7°     0      3
  6.   25%       1.54      2.46       8%        8.4°     0      5
```