### PR TITLE
Correct image used for workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,7 +51,6 @@ jobs:
             !.github*
             !.git*
             !LICENSE
-            !addons/sourcemod/scripting*
             !*.zip
             !*.fgd
           
@@ -66,7 +65,6 @@ jobs:
             !.github*
             !.git*
             !LICENSE
-            !addons/sourcemod/scripting*
             !cfg*
             !*.zip
             !*.fgd

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,13 +14,13 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:    
-    runs-on: ubuntu-20.04
-    
+  build:
+    runs-on: ubuntu-latest
+
     steps:
       # Checks-out the repository under $GITHUB_WORKSPACE
       - uses: actions/checkout@v2
-      
+
       - name: version
         run: echo "GOKZ_VERSION=$(git describe --tags --exact-match 2> /dev/null || git rev-parse --short HEAD)" >> $GITHUB_ENV
 
@@ -39,7 +39,7 @@ jobs:
           cd ../../../../
           mkdir -p addons/sourcemod/plugins
           mv sm/addons/sourcemod/scripting/gokz-*.smx addons/sourcemod/plugins
-          
+
       - name: upload-full
         uses: actions/upload-artifact@v2
         with:
@@ -53,7 +53,7 @@ jobs:
             !LICENSE
             !*.zip
             !*.fgd
-          
+
       - name: upload-upgrade
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/protect-master.yml
+++ b/.github/workflows/protect-master.yml
@@ -6,10 +6,9 @@ on:
 
 jobs:
   protect-master-pr:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     if: ${{ github.base_ref == 'master' && (github.repository != 'KZGlobalTeam/gokz' || github.head_ref != 'dev') }}
     steps:
     - uses: actions/github-script@v6
       with:
         script: core.setFailed('Trying to merge a branch into master that is not dev!')
-


### PR DESCRIPTION
Uses `ubuntu-latest` for all of the workflows.
`ubuntu-20.04` is deprecated will soon be removed by GitHub.

Let me know if `ubuntu-22.04` is more desirable for the workflows. 