### PR TITLE
Add missing filter warning, create shared ratelimit

### DIFF
--- a/addons/sourcemod/scripting/gokz-global.sp
+++ b/addons/sourcemod/scripting/gokz-global.sp
@@ -49,6 +49,9 @@ bool gB_MapValidated;
 int gI_MapID;
 int gI_MapFileSize;
 int gI_MapTier;
+bool gB_HasFilter[GOKZ_MAX_COURSES][MODE_COUNT][2];
+bool gB_FiltersLoaded;
+float gF_LastWarn[MAXPLAYERS + 1];
 
 ConVar gCV_gokz_settings_enforcer;
 ConVar gCV_gokz_warn_for_non_global_map;
@@ -233,6 +236,7 @@ public void OnClientPutInServer(int client)
 {
 	gB_GloballyVerified[client] = false;
 	gB_waitingForFPSKick[client] = false;
+	gF_LastWarn[client] = 0.0;
 	ResetPoints(client);
 	OnClientPutInServer_PrintRecords(client);
 }
@@ -259,12 +263,37 @@ public Action GOKZ_OnTimerStart(int client, int course)
 	int mode = player.Mode;
 
 	// We check the timer running to prevent spam when standing inside VB.
-	if (gCV_gokz_warn_for_non_global_map.BoolValue
-		&& GlobalAPI_HasAPIKey()
-		&& !GlobalsEnabled(mode)
-		&& !GOKZ_GetTimerRunning(client))
+	if (!gCV_gokz_warn_for_non_global_map.BoolValue || GOKZ_GetTimerRunning(client))
 	{
+		return Plugin_Continue;
+	}
+
+	// Both warnings share the same rate-limit timestamp, so only one warning fires per interval (the not-global one takes precedence).
+	float now = GetEngineTime();
+	if (now - gF_LastWarn[client] < GL_WARN_INTERVAL)
+	{
+		return Plugin_Continue;
+	}
+
+	if (GlobalAPI_HasAPIKey() && !GlobalsEnabled(mode))
+	{
+		gF_LastWarn[client] = now;
 		GOKZ_PrintToChat(client, true, "%t", "Warn Player Not Global Run");
+	}
+	else if (GlobalsEnabled(mode)
+		&& gB_FiltersLoaded
+		&& course >= 0 && course < GOKZ_MAX_COURSES
+		&& !CourseHasAnyFilter(course, mode))
+	{
+		gF_LastWarn[client] = now;
+		if (course == 0)
+		{
+			GOKZ_PrintToChat(client, true, "%t", "Warn Player No Filter Main", gC_ModeNamesShort[mode]);
+		}
+		else
+		{
+			GOKZ_PrintToChat(client, true, "%t", "Warn Player No Filter Bonus", gC_ModeNamesShort[mode], course);
+		}
 	}
 
 	return Plugin_Continue;
@@ -328,6 +357,21 @@ public void OnMapStart()
 	gI_CurrentMapFileSize = GetCurrentMapFileSize();
 	
 	gB_BannedCommandsCheck = true;
+	
+	// Reset cached map data so a stale cache from the previous map can't leak in.
+	gB_FiltersLoaded = false;
+	for (int course = 0; course < GOKZ_MAX_COURSES; course++)
+	{
+		for (int mode = 0; mode < MODE_COUNT; mode++)
+		{
+			gB_HasFilter[course][mode][0] = false;
+			gB_HasFilter[course][mode][1] = false;
+		}
+	}
+	for (int client = 1; client <= MaxClients; client++)
+	{
+		gF_LastWarn[client] = 0.0;
+	}
 	
 	// Prevent just reloading the plugin after messing with the map
 	if (gB_JustLateLoaded)
@@ -664,6 +708,17 @@ public int GetMapCallback(JSON_Object map_json, GlobalAPIRequestData request)
 	gI_MapFileSize = map.Filesize;
 	gI_MapTier = map.Difficulty;
 	
+	// Fetch all record filters for this map so we can warn players running unfiltered courses,
+	// and skip submitting times that would be rejected.
+	if (gI_MapID > 0)
+	{
+		int mapIds[1];
+		mapIds[0] = gI_MapID;
+		int tickRates[1];
+		tickRates[0] = 128;
+		GlobalAPI_GetRecordFilters(GetRecordFiltersCallback, _, _, _, mapIds, 1, _, _, _, _, tickRates, 1);
+	}
+	
 	// We don't do that earlier cause we need the map ID
 	for (int client = 1; client <= MaxClients; client++)
 	{
@@ -673,6 +728,92 @@ public int GetMapCallback(JSON_Object map_json, GlobalAPIRequestData request)
 		}
 	}
 	return 0;
+}
+
+public int GetRecordFiltersCallback(JSON_Object filters_json, GlobalAPIRequestData request)
+{
+	if (request.Failure || filters_json == INVALID_HANDLE)
+	{
+		LogError("Failed to fetch record filters for map id %d.", gI_MapID);
+		return 0;
+	}
+	
+	if (!filters_json.IsArray)
+	{
+		LogError("GlobalAPI returned a malformed response while looking up record filters.");
+		return 0;
+	}
+	
+	for (int course = 0; course < GOKZ_MAX_COURSES; course++)
+	{
+		for (int mode = 0; mode < MODE_COUNT; mode++)
+		{
+			gB_HasFilter[course][mode][0] = false;
+			gB_HasFilter[course][mode][1] = false;
+		}
+	}
+	
+	for (int i = 0; i < filters_json.Length; i++)
+	{
+		APIRecordFilter filter = view_as<APIRecordFilter>(view_as<JSON_Array>(filters_json).GetObject(i));
+		int mode = GOKZ_GL_FromGlobalMode(view_as<GlobalMode>(filter.ModeId));
+		if (mode == -1)
+		{
+			continue;
+		}
+		int course = filter.Stage;
+		if (course < 0 || course >= GOKZ_MAX_COURSES)
+		{
+			continue;
+		}
+		// HasTeleports == true => NUB filter (TimeType_Nub == 0)
+		// HasTeleports == false => PRO filter (TimeType_Pro == 1)
+		gB_HasFilter[course][mode][filter.HasTeleports ? TimeType_Nub : TimeType_Pro] = true;
+	}
+	
+	gB_FiltersLoaded = true;
+	
+	// Warn any client whose timer is already running on a course+mode that has no filter.
+	if (gCV_gokz_warn_for_non_global_map.BoolValue)
+	{
+		float now = GetEngineTime();
+		for (int client = 1; client <= MaxClients; client++)
+		{
+			if (!IsValidClient(client) || IsFakeClient(client) || !GOKZ_GetTimerRunning(client))
+			{
+				continue;
+			}
+			if (now - gF_LastWarn[client] < GL_WARN_INTERVAL)
+			{
+				continue;
+			}
+			KZPlayer player = KZPlayer(client);
+			int mode = player.Mode;
+			int course = GOKZ_GetCourse(client);
+			if (course < 0 || course >= GOKZ_MAX_COURSES || !GlobalsEnabled(mode))
+			{
+				continue;
+			}
+			if (!CourseHasAnyFilter(course, mode))
+			{
+				gF_LastWarn[client] = now;
+				if (course == 0)
+				{
+					GOKZ_PrintToChat(client, true, "%t", "Warn Player No Filter Main", gC_ModeNamesShort[mode]);
+				}
+				else
+				{
+					GOKZ_PrintToChat(client, true, "%t", "Warn Player No Filter Bonus", gC_ModeNamesShort[mode], course);
+				}
+			}
+		}
+	}
+	return 0;
+}
+
+bool CourseHasAnyFilter(int course, int mode)
+{
+	return gB_HasFilter[course][mode][TimeType_Nub] || gB_HasFilter[course][mode][TimeType_Pro];
 }
 
 void CheckClientGlobalBan(int client)

--- a/addons/sourcemod/scripting/gokz-global.sp
+++ b/addons/sourcemod/scripting/gokz-global.sp
@@ -104,6 +104,8 @@ public void OnPluginStart()
 	CreateConVars();
 	CreateGlobalForwards();
 	RegisterCommands();
+
+	CreateTimer(GL_API_RECHECK_INTERVAL, RecheckAPIStatus, INVALID_HANDLE, TIMER_REPEAT);
 }
 
 public void OnAllPluginsLoaded()
@@ -637,11 +639,46 @@ static void SetupAPI()
 	}
 }
 
+Action RecheckAPIStatus(Handle timer)
+{
+	if (!GlobalAPI_IsInit())
+	{
+		return Plugin_Continue;
+	}
+	
+	GlobalAPI_GetAuthStatus(GetAuthStatusCallback);
+	
+	bool anyModeMissing = false;
+	for (int i = 0; i < MODE_COUNT; i++)
+	{
+		if (!gB_ModeCheck[i])
+		{
+			anyModeMissing = true;
+			break;
+		}
+	}
+	if (anyModeMissing)
+	{
+		GlobalAPI_GetModes(GetModeInfoCallback);
+	}
+	
+	if (!MapCheck() && gC_CurrentMap[0] != '\0')
+	{
+		GlobalAPI_GetMapByName(GetMapCallback, _, gC_CurrentMap);
+	}
+	
+	return Plugin_Continue;
+}
+
 public int GetAuthStatusCallback(JSON_Object auth_json, GlobalAPIRequestData request)
 {
 	if (request.Failure)
 	{
-		LogError("Failed to check API key with Global API.");
+		if (gB_APIKeyCheck)
+		{
+			LogError("Failed to check API key with Global API. Global submissions disabled until connectivity is restored.");
+		}
+		gB_APIKeyCheck = false;
 		return 0;
 	}
 	

--- a/addons/sourcemod/scripting/gokz-global/commands.sp
+++ b/addons/sourcemod/scripting/gokz-global/commands.sp
@@ -47,6 +47,12 @@ public Action CommandFilterCheck(int client, int args)
 		}
 	}
 
+	if (gB_FiltersLoaded)
+	{
+		PrintFilterCheck(client, course);
+		return Plugin_Handled;
+	}
+
 	DataPack dp = CreateDataPack();
 	dp.WriteCell(GetClientUserId(client));
 	dp.WriteCell(course);
@@ -60,6 +66,18 @@ public Action CommandFilterCheck(int client, int args)
 
 	GlobalAPI_GetRecordFilters(FilterCheckCallback, dp, _, _, mapIds, 1, stages, 1, _, _, tickRates, 1);
 	return Plugin_Handled;
+}
+
+static void PrintFilterCheck(int client, int course)
+{
+	GOKZ_PrintToChat(client, true, "%t", "Filter Check Header", gC_CurrentMap, course);
+	for (int mode = 0; mode < MODE_COUNT; mode++)
+	{
+		GOKZ_PrintToChat(client, false, "%t", "Filter Check Mode",
+			gC_ModeNames[mode],
+			gB_HasFilter[course][mode][TimeType_Pro] ? "{green}✓" : "{darkred}X",
+			gB_HasFilter[course][mode][TimeType_Nub] ? "{green}✓" : "{darkred}X");
+	}
 }
 
 public int FilterCheckCallback(JSON_Object filters_json, GlobalAPIRequestData request, DataPack dp)

--- a/addons/sourcemod/scripting/gokz-global/send_run.sp
+++ b/addons/sourcemod/scripting/gokz-global/send_run.sp
@@ -19,11 +19,23 @@ void SendTime(int client, int course, float time, int teleportsUsed)
 	
 	if (GlobalsEnabled(mode))
 	{
+		// If filters have been loaded, skip the submission when the API would reject it.
+		int timeType = GOKZ_GetTimeTypeEx(teleportsUsed);
+		if (gB_FiltersLoaded && course >= 0 && course < GOKZ_MAX_COURSES)
+		{
+			bool wouldSave = gB_HasFilter[course][mode][TimeType_Nub]
+				|| (timeType == TimeType_Pro && gB_HasFilter[course][mode][TimeType_Pro]);
+			if (!wouldSave)
+			{
+				return;
+			}
+		}
+		
 		DataPack dp = CreateDataPack();
 		dp.WriteCell(GetClientUserId(client));
 		dp.WriteCell(course);
 		dp.WriteCell(mode);
-		dp.WriteCell(GOKZ_GetTimeTypeEx(teleportsUsed));
+		dp.WriteCell(timeType);
 		dp.WriteFloat(time);
 		
 		GetClientAuthId(client, AuthId_Steam2, steamid, sizeof(steamid));

--- a/addons/sourcemod/scripting/gokz-global/send_run.sp
+++ b/addons/sourcemod/scripting/gokz-global/send_run.sp
@@ -63,6 +63,7 @@ public int SendTimeCallback(JSON_Object response, GlobalAPIRequestData request, 
 	if (request.Failure)
 	{
 		LogError("Failed to send a time to the global API.");
+		GlobalAPI_GetAuthStatus(GetAuthStatusCallback);
 		return 0;
 	}
 	

--- a/addons/sourcemod/scripting/include/gokz/global.inc
+++ b/addons/sourcemod/scripting/include/gokz/global.inc
@@ -61,6 +61,7 @@ enum GlobalMode
 #define GL_FPS_MAX_KICK_TIMEOUT 10.0
 #define GL_FPS_MAX_MIN_VALUE 120
 #define GL_MYAW_MAX_VALUE 0.3
+#define GL_WARN_INTERVAL 30.0
 
 stock char gC_EnforcedCVars[ENFORCEDCVAR_COUNT][] = 
 {

--- a/addons/sourcemod/scripting/include/gokz/global.inc
+++ b/addons/sourcemod/scripting/include/gokz/global.inc
@@ -62,6 +62,7 @@ enum GlobalMode
 #define GL_FPS_MAX_MIN_VALUE 120
 #define GL_MYAW_MAX_VALUE 0.3
 #define GL_WARN_INTERVAL 30.0
+#define GL_API_RECHECK_INTERVAL 60.0
 
 stock char gC_EnforcedCVars[ENFORCEDCVAR_COUNT][] = 
 {

--- a/addons/sourcemod/translations/gokz-global.phrases.txt
+++ b/addons/sourcemod/translations/gokz-global.phrases.txt
@@ -212,6 +212,18 @@
 		"en"		"{yellow}Warning{grey}: The current map did not pass the Global check. Global times will not save. See {default}!globalcheck{grey} for more information."
 		"chi"		"{yellow}警告{grey}: 当前地图并未通过全球检查，记录将不会上传，使用 {default}!gc{grey} 指令查看详情."
 	}
+	"Warn Player No Filter Main"
+	{
+		// Warning: SKZ mode is not allowed on the main course. Global times will not save.
+		"#format"	"{1:s}"
+		"en"		"{yellow}Warning{grey}: {purple}{1}{grey} mode is not allowed on the {default}main course{grey}. Global times will not save. See {default}!filtercheck{grey} for more information."
+	}
+	"Warn Player No Filter Bonus"
+	{
+		// Warning: SKZ mode is not allowed on Bonus 1. Global times will not save.
+		"#format"	"{1:s},{2:d}"
+		"en"		"{yellow}Warning{grey}: {purple}{1}{grey} mode is not allowed on {bluegrey}Bonus {2}{grey}. Global times will not save. See {default}!filtercheck{grey} for more information."
+	}
 	"Filter Check Header"
 	{
 		// kz_map course 0 filters:


### PR DESCRIPTION
We now check that the player's mode has a filter for the course as well and warn them if it doesn't. If the map/server isn't global at all it will warn about that instead. Warning can trigger once with timer running if filters weren't checked and cached already.
Resolves #355 

Also created ratelimit of 30 seconds for when starting runs over and over to not spam it.
Resolves #360 

Periodically checking global status for (almost) live status. 
Resolves #217 

If we have checked filters and cached it the server will no longer try to submit runs to the API for modes that have no filter.