### PR TITLE
Fix restart timer preservation for locked virtual starts on other courses

### DIFF
--- a/addons/sourcemod/scripting/gokz-core/teleports.sp
+++ b/addons/sourcemod/scripting/gokz-core/teleports.sp
@@ -465,7 +465,7 @@ void TeleportToStart(int client)
 	}
 	
 	if (startType[client] != StartPositionType_MapButton
-		&& (!InRangeOfVirtualStart(client) || !CanReachVirtualStart(client)))
+		&& !CanUseVirtualStartForCourse(client, GetCurrentCourse(client)))
 	{
 		GOKZ_StopTimer(client, false);
 	}

--- a/addons/sourcemod/scripting/gokz-core/timer/virtual_buttons.sp
+++ b/addons/sourcemod/scripting/gokz-core/timer/virtual_buttons.sp
@@ -37,6 +37,14 @@ bool GetHasVirtualEndButton(int client)
 	return hasVirtualEndButton[client];
 }
 
+bool CanUseVirtualStartForCourse(int client, int course)
+{
+	float position[3];
+	return GetVirtualButtonPosition(client, position, true) == course
+		&& InRangeOfVirtualStart(client)
+		&& CanReachVirtualStart(client);
+}
+
 bool ToggleVirtualButtonsLock(int client)
 {
 	virtualButtonsLocked[client] = !virtualButtonsLocked[client];

--- a/addons/sourcemod/scripting/gokz-core/timer/virtual_buttons.sp
+++ b/addons/sourcemod/scripting/gokz-core/timer/virtual_buttons.sp
@@ -40,7 +40,8 @@ bool GetHasVirtualEndButton(int client)
 bool CanUseVirtualStartForCourse(int client, int course)
 {
 	float position[3];
-	return GetVirtualButtonPosition(client, position, true) == course
+	return GetHasVirtualStartButton(client)
+		&& GetVirtualButtonPosition(client, position, true) == course
 		&& InRangeOfVirtualStart(client)
 		&& CanReachVirtualStart(client);
 }


### PR DESCRIPTION
Fixes a bug where `!restart` could preserve the timer using a locked virtual start from a different course