### PR TITLE
Address issues with live api status checks

### DIFF
--- a/addons/sourcemod/scripting/gokz-global.sp
+++ b/addons/sourcemod/scripting/gokz-global.sp
@@ -35,6 +35,7 @@ public Plugin myinfo =
 bool gB_GOKZLocalDB;
 
 bool gB_APIKeyCheck;
+int gI_AuthFailCount;
 bool gB_ModeCheck[MODE_COUNT];
 bool gB_BannedCommandsCheck;
 char gC_CurrentMap[64];
@@ -310,6 +311,11 @@ public void GOKZ_OnTimerStart_Post(int client, int course)
 
 public void GOKZ_OnTimerEnd_Post(int client, int course, float time, int teleportsUsed)
 {
+	if (!gB_InValidRun[client] && GlobalsEnabled(KZPlayer(client).Mode))
+	{
+		gB_InValidRun[client] = true;
+	}
+
 	if (gB_GloballyVerified[client] && gB_InValidRun[client])
 	{
 		SendTime(client, course, time, teleportsUsed);
@@ -681,14 +687,17 @@ public int GetAuthStatusCallback(JSON_Object auth_json, GlobalAPIRequestData req
 {
 	if (request.Failure)
 	{
-		if (gB_APIKeyCheck)
+		gI_AuthFailCount++;
+		if (gB_APIKeyCheck && gI_AuthFailCount >= GL_API_AUTH_FAIL_THRESHOLD)
 		{
-			LogError("Failed to check API key with Global API. Global submissions disabled until connectivity is restored.");
+			LogError("Failed to check API key with Global API %d times in a row. Global status disabled until connectivity is restored.", gI_AuthFailCount);
+			gB_APIKeyCheck = false;
 		}
-		gB_APIKeyCheck = false;
 		return 0;
 	}
-	
+
+	gI_AuthFailCount = 0;
+
 	APIAuth auth = view_as<APIAuth>(auth_json);
 	if (!auth.IsValid)
 	{

--- a/addons/sourcemod/scripting/gokz-global/send_run.sp
+++ b/addons/sourcemod/scripting/gokz-global/send_run.sp
@@ -16,33 +16,31 @@ void SendTime(int client, int course, float time, int teleportsUsed)
 	char steamid[32], modeStr[32];
 	KZPlayer player = KZPlayer(client);
 	int mode = player.Mode;
-	
-	if (GlobalsEnabled(mode))
+
+	int timeType = GOKZ_GetTimeTypeEx(teleportsUsed);
+
+	// If filters have been loaded, skip the submission when the API would reject it.
+	if (gB_FiltersLoaded && course >= 0 && course < GOKZ_MAX_COURSES)
 	{
-		// If filters have been loaded, skip the submission when the API would reject it.
-		int timeType = GOKZ_GetTimeTypeEx(teleportsUsed);
-		if (gB_FiltersLoaded && course >= 0 && course < GOKZ_MAX_COURSES)
+		bool wouldSave = gB_HasFilter[course][mode][TimeType_Nub]
+			|| (timeType == TimeType_Pro && gB_HasFilter[course][mode][TimeType_Pro]);
+		if (!wouldSave)
 		{
-			bool wouldSave = gB_HasFilter[course][mode][TimeType_Nub]
-				|| (timeType == TimeType_Pro && gB_HasFilter[course][mode][TimeType_Pro]);
-			if (!wouldSave)
-			{
-				return;
-			}
+			return;
 		}
-		
-		DataPack dp = CreateDataPack();
-		dp.WriteCell(GetClientUserId(client));
-		dp.WriteCell(course);
-		dp.WriteCell(mode);
-		dp.WriteCell(timeType);
-		dp.WriteFloat(time);
-		dp.WriteString(gC_CurrentMap);
-		
-		GetClientAuthId(client, AuthId_Steam2, steamid, sizeof(steamid));
-		GOKZ_GL_GetModeString(mode, modeStr, sizeof(modeStr));
-		GlobalAPI_CreateRecord(SendTimeCallback, dp, steamid, gI_MapID, modeStr, course, 128, teleportsUsed, time);
 	}
+
+	DataPack dp = CreateDataPack();
+	dp.WriteCell(GetClientUserId(client));
+	dp.WriteCell(course);
+	dp.WriteCell(mode);
+	dp.WriteCell(timeType);
+	dp.WriteFloat(time);
+	dp.WriteString(gC_CurrentMap);
+
+	GetClientAuthId(client, AuthId_Steam2, steamid, sizeof(steamid));
+	GOKZ_GL_GetModeString(mode, modeStr, sizeof(modeStr));
+	GlobalAPI_CreateRecord(SendTimeCallback, dp, steamid, gI_MapID, modeStr, course, 128, teleportsUsed, time);
 }
 
 public int SendTimeCallback(JSON_Object response, GlobalAPIRequestData request, DataPack dp)

--- a/addons/sourcemod/scripting/include/gokz/global.inc
+++ b/addons/sourcemod/scripting/include/gokz/global.inc
@@ -63,6 +63,7 @@ enum GlobalMode
 #define GL_MYAW_MAX_VALUE 0.3
 #define GL_WARN_INTERVAL 30.0
 #define GL_API_RECHECK_INTERVAL 60.0
+#define GL_API_AUTH_FAIL_THRESHOLD 5
 
 stock char gC_EnforcedCVars[ENFORCEDCVAR_COUNT][] = 
 {


### PR DESCRIPTION
Only mark api as down if 5 checks in a row fail. 
If a run was valid, let it get sent regardless of api status (on run start or end)
